### PR TITLE
Fix CUDA kd tree (broken by the flann::Matrix::stride change)

### DIFF
--- a/test/flann_cuda_test.cu
+++ b/test/flann_cuda_test.cu
@@ -290,8 +290,8 @@ TEST_F(Flann_3D_Random_Cloud, Test4NNGpuBuffers)
 	}
 	thrust::device_vector<float4> query_device = query_host;
 	
-	flann::Matrix<float> data_device_matrix( (float*)thrust::raw_pointer_cast(&data_device[0]),data.rows,3,4);
-	flann::Matrix<float> query_device_matrix( (float*)thrust::raw_pointer_cast(&query_device[0]),data.rows,3,4);
+	flann::Matrix<float> data_device_matrix( (float*)thrust::raw_pointer_cast(&data_device[0]),data.rows,3,4*4);
+	flann::Matrix<float> query_device_matrix( (float*)thrust::raw_pointer_cast(&query_device[0]),data.rows,3,4*4);
 	
 	flann::KDTreeCuda3dIndexParams index_params;
 	index_params["input_is_gpu_float4"]=true;
@@ -402,7 +402,7 @@ TEST_F(Flann_3D_Random_Cloud, TestRadiusSearchMatrix)
 	flann::SearchParams counting_params;
 	counting_params.max_neighbors=0;
 	start_timer("counting neighbors...");
-	index.radiusSearch( query, counts,dists, r*r, counting_params );
+	index.radiusSearch( query, counts,dummy, r*r, counting_params );
 	printf("done (%g seconds)", stop_timer());
 	
 	int max_neighbors=0;


### PR DESCRIPTION
Hi Marius, 
I noticed that the changed meaning of flann::Matrix::stride broke the cuda kd tree, since there, it was expected to be in units of sizeof(DataType), not in bytes.

I fixed the test and the kd tree code to work with the new meaning, even though I somehow dislike it. (I don't like the fact that "stride" and "cols" now have different "units", even though I can see a use case for the new semantics.)

Cheers,
Andreas
