### PR TITLE
Don' require libflann_cpp-gd in pkg-config file.

### DIFF
--- a/cmake/flann.pc.in
+++ b/cmake/flann.pc.in
@@ -8,6 +8,6 @@ Name: @PROJECT_NAME@
 Description: @PKG_DESC@
 Version: @FLANN_VERSION@
 Requires: @PKG_EXTERNAL_DEPS@
-Libs: -L${libdir} -lflann_cpp -lflann_cpp-gd
+Libs: -L${libdir} -lflann_cpp
 Cflags: -I${includedir}
 


### PR DESCRIPTION
Hi Marius,

There is no libflann_cpp-gd on Linux (afaik).

Cheers,

Jochen
