### PR TITLE
fix bug in lsh_table under C++11 and gcc

### DIFF
--- a/src/cpp/flann/util/lsh_table.h
+++ b/src/cpp/flann/util/lsh_table.h
@@ -188,7 +188,7 @@ public:
     void add(Matrix<ElementType> dataset)
     {
 #if USE_UNORDERED_MAP
-        if (!use_speed_) buckets_space_.rehash((buckets_space_.size() + dataset.rows) * 1.2);
+        buckets_space_.rehash((buckets_space_.size() + dataset.rows) * 1.2);
 #endif
         // Add the features to the table
         for (unsigned int i = 0; i < dataset.rows; ++i) add(i, dataset[i]);


### PR DESCRIPTION
there was some remain of the old API
