### PR TITLE
Add /bigobj WIN32 compile flag 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ include_directories(${PROJECT_SOURCE_DIR}/src/cpp)
 if (WIN32)
     # lots of warnings with cl.exe right now
     #add_definitions( "/W1" )
-	add_definitions("-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS")
+	add_definitions("-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS /bigobj")
 else(WIN32)
     add_definitions( "-Wall" )
 endif(WIN32)


### PR DESCRIPTION
I had to add /bigobj to the compilation flags on a 32 bit system to get things to compile. You probably want to make this change contingent on the specific platform, though I don't think it will hurt either way.
