### PR TITLE
add matlab interface for radius search

### DIFF
--- a/src/matlab/flann_radius_search.m
+++ b/src/matlab/flann_radius_search.m
@@ -1,0 +1,84 @@
+%Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.
+%Copyright 2008-2009  David G. Lowe (lowe@cs.ubc.ca). All rights reserved.
+%
+%THE BSD LICENSE
+%
+%Redistribution and use in source and binary forms, with or without
+%modification, are permitted provided that the following conditions
+%are met:
+%
+%1. Redistributions of source code must retain the above copyright
+%   notice, this list of conditions and the following disclaimer.
+%2. Redistributions in binary form must reproduce the above copyright
+%   notice, this list of conditions and the following disclaimer in the
+%   documentation and/or other materials provided with the distribution.
+%
+%THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+%IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+%OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+%IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+%INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+%NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+%DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+%THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+%(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+%THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+function [indices, dists] = flann_radius_search(data, testset, radius, search_params)
+%RN_SEARCH  Perform radius search
+%
+% Performs a radius search using an
+% index constructed using flann_build_index or directly a 
+% dataset.
+
+% Marius Muja, January 2008
+% March 2013, modified from flann_search.m
+
+
+    algos = struct( 'linear', 0, 'kdtree', 1, 'kmeans', 2, 'composite', 3, 'kdtree_single', 4, 'hierarchical', 5, 'lsh', 6, 'saved', 254, 'autotuned', 255 );
+    center_algos = struct('random', 0, 'gonzales', 1, 'kmeanspp', 2 );
+    log_levels = struct('none', 0, 'fatal', 1, 'error', 2, 'warning', 3, 'info', 4);
+    function value = id2value(map, id)
+        fields = fieldnames(map);
+        for i = 1:length(fields),
+            val = cell2mat(fields(i));
+            if map.(val) == id
+                value = val;
+                break;
+            end
+        end
+    end
+    function id = value2id(map,value)
+        id = map.(value);
+    end
+
+    default_params = struct('algorithm', 'kdtree' ,'checks', 32, 'eps', 0.0, 'sorted', 1, 'max_neighbors', -1, 'cores', 1, 'trees', 4, 'leaf_max_size', 15, 'branching', 32, 'iterations', 5, 'centers_init', 'random', 'cb_index', 0.4, 'target_precision', 0.9,'build_weight', 0.01, 'memory_weight', 0, 'sample_fraction', 0.1, 'log_level', 'warning', 'random_seed', 0);
+
+    if ~isstruct(search_params)
+        error('The "search_params" argument must be a structure');
+    end
+
+    params = default_params;
+    fn = fieldnames(search_params);
+    for i = [1:length(fn)],
+        name = cell2mat(fn(i));
+        params.(name) = search_params.(name);
+    end
+    if ~isnumeric(params.algorithm),
+        params.algorithm = value2id(algos,params.algorithm);
+    end
+    if ~isnumeric(params.centers_init),
+        params.centers_init = value2id(center_algos,params.centers_init);
+    end
+    if ~isnumeric(params.log_level),
+        params.log_level = value2id(log_levels,params.log_level);
+    end
+
+    if (size(data,1)==1 && size(data,2)==1)
+        % we already have an index
+        [indices,dists] = nearest_neighbors('index_find_rn', data, testset, radius, params);
+    else
+        % create the index and search
+        [indices,dists] = nearest_neighbors('find_rn', data, testset, radius, params);
+    end
+end

--- a/src/matlab/nearest_neighbors.cpp
+++ b/src/matlab/nearest_neighbors.cpp
@@ -62,6 +62,7 @@ static void matlabStructToFlannStruct( const mxArray* mexParams, FLANNParameters
 
     // kdtree
     flannParams.trees = (int)*(mxGetPr(mxGetField(mexParams, 0,"trees")));
+    flannParams.leaf_max_size = (int)*(mxGetPr(mxGetField(mexParams, 0,"leaf_max_size")));
 
     // kmeans
     flannParams.branching = (int)*(mxGetPr(mxGetField(mexParams, 0,"branching")));
@@ -100,7 +101,7 @@ static mxArray* flannStructToMatlabStruct( const FLANNParameters& flannParams )
     mxSetField(mexParams, 0, "cores", to_mx_array(flannParams.cores));
 
     mxSetField(mexParams, 0, "trees", to_mx_array(flannParams.trees));
-    mxSetField(mexParams, 0, "leaf_max_size", to_mx_array(flannParams.trees));
+    mxSetField(mexParams, 0, "leaf_max_size", to_mx_array(flannParams.leaf_max_size));
     
     mxSetField(mexParams, 0, "branching", to_mx_array(flannParams.branching));
     mxSetField(mexParams, 0, "iterations", to_mx_array(flannParams.iterations));
@@ -579,6 +580,415 @@ static void _load_index(int nOutArray, mxArray* OutArray[], int nInArray, const 
     pOut[0] = typedIndex;
 }
 
+flann::IndexParams _create_parameters_mex(FLANNParameters* p)
+{
+    flann::IndexParams params;
+
+    params["algorithm"] = p->algorithm;
+
+    params["checks"] = p->checks;
+    params["cb_index"] = p->cb_index;
+    params["eps"] = p->eps;
+
+    if (p->algorithm == FLANN_INDEX_KDTREE) {
+        params["trees"] = p->trees;
+    }
+
+    if (p->algorithm == FLANN_INDEX_KDTREE_SINGLE) {
+        params["trees"] = p->trees;
+        params["leaf_max_size"] = p->leaf_max_size;
+    }
+
+#ifdef FLANN_USE_CUDA
+    if (p->algorithm == FLANN_INDEX_KDTREE_CUDA) {
+        params["leaf_max_size"] = p->leaf_max_size;
+    }
+#endif
+
+    if (p->algorithm == FLANN_INDEX_KMEANS) {
+        params["branching"] = p->branching;
+        params["iterations"] = p->iterations;
+        params["centers_init"] = p->centers_init;
+    }
+
+    if (p->algorithm == FLANN_INDEX_AUTOTUNED) {
+        params["target_precision"] = p->target_precision;
+        params["build_weight"] = p->build_weight;
+        params["memory_weight"] = p->memory_weight;
+        params["sample_fraction"] = p->sample_fraction;
+    }
+
+    if (p->algorithm == FLANN_INDEX_HIERARCHICAL) {
+        params["branching"] = p->branching;
+        params["centers_init"] = p->centers_init;
+        params["trees"] = p->trees;
+        params["leaf_max_size"] = p->leaf_max_size;
+    }
+
+    if (p->algorithm == FLANN_INDEX_LSH) {
+        params["table_number"] = p->table_number_;
+        params["key_size"] = p->key_size_;
+        params["multi_probe_level"] = p->multi_probe_level_;
+    }
+
+    params["log_level"] = p->log_level;
+    params["random_seed"] = p->random_seed;
+
+    return params;
+}
+
+flann::SearchParams _create_search_params_mex(FLANNParameters* p)
+{
+    flann::SearchParams params;
+    params.checks = p->checks;
+    params.eps = p->eps;
+    params.sorted = p->sorted;
+    params.max_neighbors = p->max_neighbors;
+    params.cores = p->cores;
+
+    return params;
+}
+
+template<typename Distance>
+int __flann_radius_search_mex(typename Distance::ElementType* dataset,  int rows, int cols, 
+                          typename Distance::ElementType* testset, int tcount,
+                          std::vector<std::vector<int> >& indices,
+                          std::vector<std::vector<typename Distance::ResultType> >& dists,
+                          float radius,
+                          FLANNParameters* flann_params, Distance d = Distance())
+{
+    typedef typename Distance::ElementType ElementType;
+    typedef typename Distance::ResultType DistanceType;
+
+    try {
+        if (flann_params->random_seed>0) {
+            seed_random(flann_params->random_seed);
+        }
+
+        flann::IndexParams params = _create_parameters_mex(flann_params);
+        flann::Index<Distance>* index = new flann::Index<Distance>(Matrix<ElementType>(dataset,rows,cols), params, d);
+        index->buildIndex();
+
+        flann::SearchParams search_params = _create_search_params_mex(flann_params);
+        int count = index->radiusSearch(flann::Matrix<ElementType>(testset, tcount, index->veclen()),
+                                        indices,
+                                        dists, radius, search_params );
+
+        delete index;
+        return count;
+    }
+    catch (std::runtime_error& e) {
+        std::string estr(e.what());
+        estr = "Caught exception: " + estr;
+        mexErrMsgTxt(estr.c_str());
+        return -1;
+    }
+}
+
+template<typename Distance>
+int __flann_radius_search_index_mex(flann_index_t index_ptr,
+                          typename Distance::ElementType* testset, int tcount,
+                          std::vector<std::vector<int> >& indices,
+                          std::vector<std::vector<typename Distance::ResultType> >& dists,
+                          float radius,
+                          FLANNParameters* flann_params)
+{
+    typedef typename Distance::ElementType ElementType;
+    typedef typename Distance::ResultType DistanceType;
+
+    try {
+        if (index_ptr==NULL) {
+            mexErrMsgTxt("Invalid index");
+            return -1;
+        }
+        if (flann_params->random_seed>0) {
+            seed_random(flann_params->random_seed);
+        }
+        flann::Index<Distance>* index = (flann::Index<Distance>*)index_ptr;
+
+        flann::SearchParams search_params = _create_search_params_mex(flann_params);
+        int count = index->radiusSearch(flann::Matrix<ElementType>(testset, tcount, index->veclen()),
+                                        indices,
+                                        dists, radius, search_params );
+
+
+        return count;
+    }
+    catch (std::runtime_error& e) {
+        std::string estr(e.what());
+        estr = "Caught exception: " + estr;
+        mexErrMsgTxt(estr.c_str());
+        return -1;
+    }
+}
+
+extern flann_distance_t flann_distance_type;
+extern int flann_distance_order;
+
+template<typename T, typename R>
+int _flann_radius_search_mex(T* dataset, int rows, int cols, 
+                         T* testset,
+                         int tcount,
+                         std::vector<std::vector<int> >& indices,
+                         std::vector<std::vector<R> >& dists,
+                         float radius,
+                         FLANNParameters* flann_params)
+{
+    if (flann_distance_type==FLANN_DIST_EUCLIDEAN) {
+        return __flann_radius_search_mex<L2<T> >(dataset, rows, cols, testset, tcount, indices, dists, radius, flann_params);
+    }
+    else if (flann_distance_type==FLANN_DIST_MANHATTAN) {
+        return __flann_radius_search_mex<L1<T> >(dataset, rows, cols, testset, tcount, indices, dists, radius, flann_params);
+    }
+    else if (flann_distance_type==FLANN_DIST_MINKOWSKI) {
+        return __flann_radius_search_mex<MinkowskiDistance<T> >(dataset, rows, cols, testset, tcount, indices, dists, radius, flann_params, MinkowskiDistance<T>(flann_distance_order));
+    }
+    else if (flann_distance_type==FLANN_DIST_HIST_INTERSECT) {
+        return __flann_radius_search_mex<HistIntersectionDistance<T> >(dataset, rows, cols, testset, tcount, indices, dists, radius, flann_params);
+    }
+    else if (flann_distance_type==FLANN_DIST_HELLINGER) {
+        return __flann_radius_search_mex<HellingerDistance<T> >(dataset, rows, cols, testset, tcount, indices, dists, radius, flann_params);
+    }
+    else if (flann_distance_type==FLANN_DIST_CHI_SQUARE) {
+        return __flann_radius_search_mex<ChiSquareDistance<T> >(dataset, rows, cols, testset, tcount, indices, dists, radius, flann_params);
+    }
+    else if (flann_distance_type==FLANN_DIST_KULLBACK_LEIBLER) {
+        return __flann_radius_search_mex<KL_Divergence<T> >(dataset, rows, cols, testset, tcount, indices, dists, radius, flann_params);
+    }
+    else {
+        mexErrMsgTxt( "Distance type unsupported in the C bindings, use the C++ bindings instead");
+        return -1;
+    }
+}
+
+template<typename T, typename R>
+int _flann_radius_search_index_mex(flann_index_t index_ptr,
+                         T* testset,
+                         int tcount,
+                         std::vector<std::vector<int> >& indices,
+                         std::vector<std::vector<R> >& dists,
+                         float radius,
+                         FLANNParameters* flann_params)
+{
+    if (flann_distance_type==FLANN_DIST_EUCLIDEAN) {
+        return __flann_radius_search_index_mex<L2<T> >(index_ptr, testset, tcount, indices, dists, radius, flann_params);
+    }
+    else if (flann_distance_type==FLANN_DIST_MANHATTAN) {
+        return __flann_radius_search_index_mex<L1<T> >(index_ptr, testset, tcount, indices, dists, radius, flann_params);
+    }
+    else if (flann_distance_type==FLANN_DIST_MINKOWSKI) {
+        return __flann_radius_search_index_mex<MinkowskiDistance<T> >(index_ptr, testset, tcount, indices, dists, radius, flann_params);
+    }
+    else if (flann_distance_type==FLANN_DIST_HIST_INTERSECT) {
+        return __flann_radius_search_index_mex<HistIntersectionDistance<T> >(index_ptr, testset, tcount, indices, dists, radius, flann_params);
+    }
+    else if (flann_distance_type==FLANN_DIST_HELLINGER) {
+        return __flann_radius_search_index_mex<HellingerDistance<T> >(index_ptr, testset, tcount, indices, dists, radius, flann_params);
+    }
+    else if (flann_distance_type==FLANN_DIST_CHI_SQUARE) {
+        return __flann_radius_search_index_mex<ChiSquareDistance<T> >(index_ptr, testset, tcount, indices, dists, radius, flann_params);
+    }
+    else if (flann_distance_type==FLANN_DIST_KULLBACK_LEIBLER) {
+        return __flann_radius_search_index_mex<KL_Divergence<T> >(index_ptr, testset, tcount, indices, dists, radius, flann_params);
+    }
+    else {
+        mexErrMsgTxt( "Distance type unsupported in the C bindings, use the C++ bindings instead");
+        return -1;
+    }
+}
+
+/**
+ * Input arguments: dataset (matrix), testset (matrix), radius (double),  params (struct)
+ * Output arguments: indices(matrix), dists(matrix)
+ */
+static void _find_rn(int nOutArray, mxArray* OutArray[], int nInArray, const mxArray* InArray[])
+{
+    /* Check the number of input arguments */
+    if(nInArray != 4) {
+        mexErrMsgTxt("Incorrect number of input arguments, expecting:\n"
+                     "dataset, testset, nearest_neighbors, params");
+    }
+
+    /* Check the number of output arguments */
+    if(nOutArray > 2) {
+        mexErrMsgTxt("One or two outputs required.");
+    }
+    const mxArray* datasetMat = InArray[0];
+    const mxArray* testsetMat = InArray[1];
+    check_allowed_type(datasetMat);
+    check_allowed_type(testsetMat);
+
+    int dcount = mxGetN(datasetMat);
+    int length = mxGetM(datasetMat);
+    int tcount = mxGetN(testsetMat);
+
+    if (mxGetM(testsetMat) != length) {
+        mexErrMsgTxt("Dataset and testset features should have the same size.");
+    }
+
+    const mxArray* rMat = InArray[2];
+
+    if ((mxGetM(rMat)!=1)||(mxGetN(rMat)!=1)|| !mxIsNumeric(rMat)) {
+        mexErrMsgTxt("Radius should be a scalar.");
+    }
+    double radius = (double)(*mxGetPr(rMat));
+
+    const mxArray* pStruct = InArray[3];
+
+    if (!mxIsStruct(pStruct)) {
+        mexErrMsgTxt("Params must be a struct object.");
+    }
+
+    FLANNParameters p;
+    matlabStructToFlannStruct(pStruct, p);
+
+    std::vector<std::vector<int> > result;
+    std::vector<std::vector<float> > dists;
+    std::vector<std::vector<double> > ddists;
+
+    /* do the search */
+    if (mxIsSingle(datasetMat)) {
+        float* dataset = (float*) mxGetData(datasetMat);
+        float* testset = (float*) mxGetData(testsetMat);
+        _flann_radius_search_mex(dataset,dcount,length,testset, tcount, result, dists, radius, &p);
+    }
+    else if (mxIsDouble(datasetMat)) {
+        double* dataset = (double*) mxGetData(datasetMat);
+        double* testset = (double*) mxGetData(testsetMat);
+        _flann_radius_search_mex(dataset,dcount,length,testset, tcount, result, ddists, radius, &p);
+    }
+    else if (mxIsUint8(datasetMat)) {
+        unsigned char* dataset = (unsigned char*) mxGetData(datasetMat);
+        unsigned char* testset = (unsigned char*) mxGetData(testsetMat);
+        _flann_radius_search_mex(dataset,dcount,length,testset, tcount, result, dists, radius, &p);
+    }
+    else if (mxIsInt32(datasetMat)) {
+        int* dataset = (int*) mxGetData(datasetMat);
+        int* testset = (int*) mxGetData(testsetMat);
+        _flann_radius_search_mex(dataset,dcount,length,testset, tcount, result, dists, radius, &p);
+    }
+
+    OutArray[0] = mxCreateCellMatrix(1, tcount);
+    if (nOutArray > 1) {
+        OutArray[1] = mxCreateCellMatrix(1, tcount);
+    }
+    for (size_t i=0; i<result.size(); ++i) {
+        mxArray* idxs = mxCreateDoubleMatrix(result[i].size(), 1, mxREAL);
+        double *pOut = mxGetPr(idxs);
+        for (size_t j=0; j<result[i].size(); ++j)
+            pOut[j] = result[i][j] + 1; // matlab uses 1-based indexing
+        mxSetCell(OutArray[0], i, idxs);
+
+        if (nOutArray > 1) {
+            mxArray* mdists = mxCreateDoubleMatrix(result[i].size(), 1, mxREAL);
+            double* pDists = mxGetPr(mdists);
+            for (size_t j=0; j<result[i].size(); ++j) {
+                if (!dists.empty()) {
+                    pDists[j] = dists[i][j];
+                }
+                if (!ddists.empty()) {
+                    pDists[j] = ddists[i][j];
+                }
+            }
+            mxSetCell(OutArray[1], i, mdists);
+        }
+    }
+}
+
+/**
+ * Input arguments: index (pointer), testset (matrix), radius (double),  params (struct)
+ * Output arguments: indices(matrix), dists(matrix)
+ */
+static void _index_find_rn(int nOutArray, mxArray* OutArray[], int nInArray, const mxArray* InArray[])
+{
+    /* Check the number of input arguments */
+    if(nInArray != 4) {
+        mexErrMsgTxt("Incorrect number of input arguments");
+    }
+    /* Check if there is one Output matrix */
+    if(nOutArray > 2) {
+        mexErrMsgTxt("One or two outputs required.");
+    }
+
+    const mxArray* indexMat = InArray[0];
+    TypedIndex* typedIndex = *(TypedIndex**)mxGetData(indexMat);
+
+    const mxArray* testsetMat = InArray[1];
+    check_allowed_type(testsetMat);
+
+    int tcount = mxGetN(testsetMat);
+
+    const mxArray* rMat = InArray[2];
+
+    if ((mxGetM(rMat)!=1)||(mxGetN(rMat)!=1)) {
+        mexErrMsgTxt("Radius should be a scalar.");
+    }
+    double radius = (double)(*mxGetPr(rMat));
+
+    const mxArray* pStruct = InArray[3];
+
+    FLANNParameters p;
+    matlabStructToFlannStruct(pStruct, p);
+
+    std::vector<std::vector<int> > result;
+    std::vector<std::vector<float> > dists;
+    std::vector<std::vector<double> > ddists;
+
+    if (mxIsSingle(testsetMat)) {
+        if (typedIndex->type != FLANN_FLOAT32) {
+            mexErrMsgTxt("Index type must match testset type");
+        }
+        float* testset = (float*) mxGetData(testsetMat);
+        _flann_radius_search_index_mex(typedIndex->index, testset, tcount, result, dists, radius, &p);
+    }
+    else if (mxIsDouble(testsetMat)) {
+        if (typedIndex->type != FLANN_FLOAT64) {
+            mexErrMsgTxt("Index type must match testset type");
+        }
+        double* testset = (double*) mxGetData(testsetMat);
+        _flann_radius_search_index_mex(typedIndex->index, testset, tcount, result, ddists, radius, &p);
+    }
+    else if (mxIsUint8(testsetMat)) {
+        if (typedIndex->type != FLANN_UINT8) {
+            mexErrMsgTxt("Index type must match testset type");
+        }
+        unsigned char* testset = (unsigned char*) mxGetData(testsetMat);
+        _flann_radius_search_index_mex(typedIndex->index, testset, tcount, result, dists, radius, &p);
+    }
+    else if (mxIsInt32(testsetMat)) {
+        if (typedIndex->type != FLANN_INT32) {
+            mexErrMsgTxt("Index type must match testset type");
+        }
+        int* testset = (int*) mxGetData(testsetMat);
+        _flann_radius_search_index_mex(typedIndex->index, testset, tcount, result, dists, radius, &p);
+    }
+
+    OutArray[0] = mxCreateCellMatrix(1, tcount);
+    if (nOutArray > 1) {
+        OutArray[1] = mxCreateCellMatrix(1, tcount);
+    }
+    for (size_t i=0; i<result.size(); ++i) {
+        mxArray* idxs = mxCreateDoubleMatrix(result[i].size(), 1, mxREAL);
+        double *pOut = mxGetPr(idxs);
+        for (size_t j=0; j<result[i].size(); ++j)
+            pOut[j] = result[i][j] + 1; // matlab uses 1-based indexing
+        mxSetCell(OutArray[0], i, idxs);
+
+        if (nOutArray > 1) {
+            mxArray* mdists = mxCreateDoubleMatrix(result[i].size(), 1, mxREAL);
+            double* pDists = mxGetPr(mdists);
+            for (size_t j=0; j<result[i].size(); ++j) {
+                if (!dists.empty()) {
+                    pDists[j] = dists[i][j];
+                }
+                if (!ddists.empty()) {
+                    pDists[j] = ddists[i][j];
+                }
+            }
+            mxSetCell(OutArray[1], i, mdists);
+        }
+    }
+}
 
 struct mexFunctionEntry
 {
@@ -595,6 +1005,8 @@ static mexFunctionEntry __functionTable[] = {
     { "load_index", &_load_index},
     { "set_log_level", &_set_log_level},
     { "set_distance_type", &_set_distance_type},
+    { "find_rn", &_find_rn},
+    { "index_find_rn", &_index_find_rn}
 };
 
 


### PR DESCRIPTION
Some parts of the mex cpp are copied from flann.cpp. It doesn't seem to fit in there but I don't know better way. They don't belong to the c interface either because I have to use the vector<vector<>> stuff. It will return cell array of indices and distances instead of matrix since number of neighbors of each test data will be different. 
