### PR TITLE
Fixed link error on MinGW and MSYS

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -88,6 +88,10 @@ if (BUILD_C_BINDINGS)
         target_link_libraries(flann -Wl,-whole-archive flann_s -Wl,-no-whole-archive)
     else()
         add_library(flann SHARED ${C_SOURCES})
+
+        if(MINGW)
+          target_link_libraries(flann -lgomp)
+        endif(MINGW)
     endif()
 
     set_target_properties(flann PROPERTIES


### PR DESCRIPTION
Added a library (gomp) to link in a CMakeLists.txt to build successfully with MinGW.
