### PR TITLE
Python bindings: raise KeyError if you give a bad param name

### DIFF
--- a/src/python/pyflann/flann_ctypes.py
+++ b/src/python/pyflann/flann_ctypes.py
@@ -52,6 +52,8 @@ class CustomStructure(Structure):
         for k,v in dict.items():
             if k in self.__field_names:
                 setattr(self,k,self.__translate(k,v))
+            else:
+                raise KeyError("No such member: "+k)
     
     def __getitem__(self, k):
         if k in self.__field_names:


### PR DESCRIPTION
This minor change makes it so that in the python bindings, `FLANNParameters.update` (and hence also `FLANNParameters.__init__`) raises a `KeyError` rather than silently ignoring if you give it a bad key name, just like `FLANNParameters.__setitem__`.

(I just noticed that this was masking a bug in my own code, which was mildly annoying.)
