### PR TITLE
Fix to memory errors signalled by valgrind in flann::any. 

### DIFF
--- a/src/cpp/flann/util/any.h
+++ b/src/cpp/flann/util/any.h
@@ -44,6 +44,7 @@ struct base_any_policy
     virtual void clone(void* const* src, void** dest) = 0;
     virtual void move(void* const* src, void** dest) = 0;
     virtual void* get_value(void** src) = 0;
+    virtual void* get_value(void* const * src) = 0;
     virtual ::size_t get_size() = 0;
     virtual const std::type_info& type() = 0;
     virtual void print(std::ostream& out, void* const* src) = 0;
@@ -68,6 +69,7 @@ struct small_any_policy : typed_base_any_policy<T>
     virtual void clone(void* const* src, void** dest) { *dest = *src; }
     virtual void move(void* const* src, void** dest) { *dest = *src; }
     virtual void* get_value(void** src) { return reinterpret_cast<void*>(src); }
+    virtual void* get_value(void* const * src) { return const_cast<void *>( reinterpret_cast<const void*>(src) ); }
     virtual void print(std::ostream& out, void* const* src) { out << *reinterpret_cast<T const*>(src); }
 };
 
@@ -92,6 +94,7 @@ struct big_any_policy : typed_base_any_policy<T>
         **reinterpret_cast<T**>(dest) = **reinterpret_cast<T* const*>(src);
     }
     virtual void* get_value(void** src) { return *src; }
+    virtual void* get_value(void* const * src) { return const_cast<void*>(*src); }
     virtual void print(std::ostream& out, void* const* src) { out << *reinterpret_cast<T const*>(*src); }
 };
 
@@ -242,8 +245,7 @@ public:
     const T& cast() const
     {
         if (policy->type() != typeid(T)) throw anyimpl::bad_any_cast();
-        void* obj = const_cast<void*>(object);
-        T* r = reinterpret_cast<T*>(policy->get_value(&obj));
+        T* r = reinterpret_cast<T*>(policy->get_value(&object));
         return *r;
     }
 


### PR DESCRIPTION
Changes to any to prevent the const version of cast signalling memory errors via valgrind. Addresses #111.
