### PR TITLE
Option to disable example building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ option(BUILD_C_BINDINGS "Build C bindings" ON)
 option(BUILD_PYTHON_BINDINGS "Build Python bindings" ON)
 option(BUILD_MATLAB_BINDINGS "Build Matlab bindings" ON)
 option(BUILD_CUDA_LIB "Build CUDA library" OFF)
+option(BUILD_EXAMPLES "Build examples" ON)
 option(USE_OPENMP "Use OpenMP multi-threading" ON)
 option(USE_MPI "Use MPI" OFF)
 
@@ -154,7 +155,9 @@ endif()
 
 add_subdirectory( cmake )
 add_subdirectory( src )
-add_subdirectory( examples )
+if (BUILD_EXAMPLES)
+  add_subdirectory( examples )
+endif(BUILD_EXAMPLES)
 add_subdirectory( test )
 add_subdirectory( doc )
 


### PR DESCRIPTION
I added a cmake option to disable building of examples.  This helps me get flann to cross-compile for the iOS simulator.  I left the default ON so this change should only affect someone who explicitly sets the option.
