### PR TITLE
Refactor any to not use any const_casts

### DIFF
--- a/src/cpp/flann/util/any.h
+++ b/src/cpp/flann/util/any.h
@@ -44,7 +44,7 @@ struct base_any_policy
     virtual void clone(void* const* src, void** dest) = 0;
     virtual void move(void* const* src, void** dest) = 0;
     virtual void* get_value(void** src) = 0;
-    virtual void* get_value(void* const * src) = 0;
+    virtual const void* get_value(void* const * src) = 0;
     virtual ::size_t get_size() = 0;
     virtual const std::type_info& type() = 0;
     virtual void print(std::ostream& out, void* const* src) = 0;
@@ -69,7 +69,7 @@ struct small_any_policy : typed_base_any_policy<T>
     virtual void clone(void* const* src, void** dest) { *dest = *src; }
     virtual void move(void* const* src, void** dest) { *dest = *src; }
     virtual void* get_value(void** src) { return reinterpret_cast<void*>(src); }
-    virtual void* get_value(void* const * src) { return const_cast<void *>( reinterpret_cast<const void*>(src) ); }
+    virtual const void* get_value(void* const * src) { return reinterpret_cast<const void*>(src); }
     virtual void print(std::ostream& out, void* const* src) { out << *reinterpret_cast<T const*>(src); }
 };
 
@@ -94,7 +94,7 @@ struct big_any_policy : typed_base_any_policy<T>
         **reinterpret_cast<T**>(dest) = **reinterpret_cast<T* const*>(src);
     }
     virtual void* get_value(void** src) { return *src; }
-    virtual void* get_value(void* const * src) { return const_cast<void*>(*src); }
+    virtual const void* get_value(void* const * src) { return *src; }
     virtual void print(std::ostream& out, void* const* src) { out << *reinterpret_cast<T const*>(*src); }
 };
 
@@ -245,7 +245,7 @@ public:
     const T& cast() const
     {
         if (policy->type() != typeid(T)) throw anyimpl::bad_any_cast();
-        T* r = reinterpret_cast<T*>(policy->get_value(&object));
+        const T* r = reinterpret_cast<const T*>(policy->get_value(&object));
         return *r;
     }
 


### PR DESCRIPTION
Consider this a followup to #115. There's no need to use `const_cast`, since it's very easy to make it work in a const-correct manner.
