### PR TITLE
Support custom docdir

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,4 +1,8 @@
 find_package(LATEX)
+
+if (NOT DOCDIR)
+  set(DOCDIR share/doc/flann)
+endif ()
  
 if (EXISTS ${PDFLATEX_COMPILER} AND EXISTS ${BIBTEX_COMPILER})
     include(${PROJECT_SOURCE_DIR}/cmake/UseLATEX.cmake)
@@ -14,6 +18,6 @@ endif()
 
 install(
     FILES manual.pdf
-    DESTINATION share/doc/flann
+    DESTINATION ${DOCDIR}
     OPTIONAL
 )


### PR DESCRIPTION
Allow user to specify a custom location for docs. On some Linux distributions 
the docs are at /usr/share/doc/pkg-version rather then the unversioned dir.

Signed-off-by: Justin Lecher jlec@gentoo.org
