### PR TITLE
when computing KMeans centers on non-real points, it's better to round instead of letting the compiler truncate the centers positions 

### DIFF
--- a/src/cpp/flann/algorithms/kmeans_index.h
+++ b/src/cpp/flann/algorithms/kmeans_index.h
@@ -717,10 +717,13 @@ private:
 
                     for (int k=0; k<indices_length; ++k) {
                         if (belongs_to[k]==j) {
-                            belongs_to[k] = i;
-                            count[j]--;
-                            count[i]++;
-                            break;
+                            // for cluster j, we move the furthest element from the center to the empty cluster i
+                            if ( distance_(points_[indices[k]], dcenters[j], veclen_) == radiuses[j] ) {
+                                belongs_to[k] = i;
+                                count[j]--;
+                                count[i]++;
+                                break;
+                            }
                         }
                     }
                     converged = false;


### PR DESCRIPTION
Hi Marius,
Another small improvement for KMeans in case points positions are in an integer space.
