### PR TITLE
when computing KMeans centers on integer points, it's better to round instead of letting the compiler truncate the centers positions

### DIFF
--- a/src/cpp/flann/algorithms/kmeans_index.h
+++ b/src/cpp/flann/algorithms/kmeans_index.h
@@ -55,6 +55,69 @@
 namespace flann
 {
 
+namespace {
+
+template <typename ElementType>
+double prepareRoundingIfIntegerElementType( double value ) {
+    return value;
+};
+
+
+template <>
+double prepareRoundingIfIntegerElementType<char>( double value ) {
+    return (value > 0) ? value + 0.5 : value - 0.5;
+};
+
+template <>
+double prepareRoundingIfIntegerElementType<short>( double value ) {
+    return (value > 0) ? value + 0.5 : value - 0.5;
+};
+
+template <>
+double prepareRoundingIfIntegerElementType<int>( double value ) {
+    return (value > 0) ? value + 0.5 : value - 0.5;
+};
+
+template <>
+double prepareRoundingIfIntegerElementType<long>( double value ) {
+    return (value > 0) ? value + 0.5 : value - 0.5;
+};
+
+template <>
+double prepareRoundingIfIntegerElementType<long long>( double value ) {
+    return (value > 0) ? value + 0.5 : value - 0.5;
+};
+
+
+template <>
+double prepareRoundingIfIntegerElementType<unsigned char>( double value ) {
+    return (value + 0.5);
+};
+
+template <>
+double prepareRoundingIfIntegerElementType<unsigned short>( double value ) {
+    return (value + 0.5);
+};
+
+template <>
+double prepareRoundingIfIntegerElementType<unsigned int>( double value ) {
+    return (value + 0.5);
+};
+
+template <>
+double prepareRoundingIfIntegerElementType<unsigned long>( double value ) {
+    return (value + 0.5);
+};
+
+template <>
+double prepareRoundingIfIntegerElementType<unsigned long long>( double value ) {
+    return (value + 0.5);
+};
+
+}
+
+
+
 struct KMeansIndexParams : public IndexParams
 {
     KMeansIndexParams(int branching = 32, int iterations = 11,
@@ -620,7 +683,8 @@ private:
                 int cnt = count[i];
                 double div_factor = 1.0/cnt;
                 for (size_t k=0; k<veclen_; ++k) {
-                    dcenters[i][k] *= div_factor;
+                    dcenters[i][k] = prepareRoundingIfIntegerElementType<ElementType>( dcenters[i][k]
+                                                                                       * div_factor );
                 }
             }
 


### PR DESCRIPTION
Explanation:
dcenters[i][k] is a double, so why do we need to round it? 
Because if Distance is belonging to the Integer space, "distance_" in the line below 
    DistanceType sq_dist = distance_(dataset_[indices[i]], dcenters[j], veclen_);
will truncate dcenters[j], so that's why we add or substract 0.5 (depends on the sign) to get the same result as round().

And why don't we use round() instead? 
Because as the result is still stored in dcenters[i][k] that is a double, 6 for instance might be stored as 5.999999999

Finally, why don't we just create a template with a int result that will do the work like that:
         DistanceType new_sq_dist = distance_(dataset_[indices[i]], roundTemplate<ElementType>(dcenters[j]), veclen_);
Because we are in an inner loop, so this would slow down the process.
