### PR TITLE
Add a new method for initializing KMeans centers that leads to better clusters and thus better retrieval when final centers have to be existing keypoints instead of clusters barycenters.

### DIFF
--- a/src/cpp/flann/algorithms/hierarchical_clustering_index.h
+++ b/src/cpp/flann/algorithms/hierarchical_clustering_index.h
@@ -165,6 +165,9 @@ public:
         case FLANN_CENTERS_KMEANSPP:
             chooseCenters_ = new KMeansppCenterChooser<Distance>(distance_, points_);
         	break;
+        case FLANN_CENTERS_GROUPWISE:
+            chooseCenters_ = new GroupWiseCenterChooser<Distance>(distance_, points_);
+            break;
         default:
             throw FLANNException("Unknown algorithm for choosing initial centers.");
         }

--- a/src/cpp/flann/defines.h
+++ b/src/cpp/flann/defines.h
@@ -97,6 +97,7 @@ enum flann_centers_init_t
     FLANN_CENTERS_RANDOM = 0,
     FLANN_CENTERS_GONZALES = 1,
     FLANN_CENTERS_KMEANSPP = 2,
+    FLANN_CENTERS_GROUPWISE = 3,
 };
 
 enum flann_log_level_t


### PR DESCRIPTION
Chooses the initial centers in a way inspired by Gonzales : 
select the first point of the list as a candidate, then parse the points list. If another point is further than current candidate from the other centers, test if it is a good center of a local points aggregation. If it is, replace current candidate by this point. And so on... 

Used with HierarchicalClusteringIndex class that picks centers among existing points instead of computing the barycenters, there is a real improvement while retrieving keypoints.
