### PR TITLE
Fixes in accum_dist methods

### DIFF
--- a/src/cpp/flann/algorithms/dist.h
+++ b/src/cpp/flann/algorithms/dist.h
@@ -642,7 +642,7 @@ struct HellingerDistance
     typedef typename Accumulator<T>::Type ResultType;
 
     /**
-     *  Compute the histogram intersection distance
+     *  Compute the Hellinger distance
      */
     template <typename Iterator1, typename Iterator2>
     ResultType operator()(Iterator1 a, Iterator2 b, size_t size, ResultType /*worst_dist*/ = -1) const
@@ -675,7 +675,8 @@ struct HellingerDistance
     template <typename U, typename V>
     inline ResultType accum_dist(const U& a, const V& b, int) const
     {
-        return sqrt(static_cast<ResultType>(a)) - sqrt(static_cast<ResultType>(b));
+        ResultType dist = sqrt(static_cast<ResultType>(a)) - sqrt(static_cast<ResultType>(b));
+        return dist * dist;
     }
 };
 
@@ -751,7 +752,7 @@ struct KL_Divergence
         Iterator1 last = a + size;
 
         while (a < last) {
-            if (* a != 0) {
+            if ( *a != 0 && *b != 0 ) {
                 ResultType ratio = (ResultType)(*a / *b);
                 if (ratio>0) {
                     result += *a * log(ratio);
@@ -774,10 +775,12 @@ struct KL_Divergence
     inline ResultType accum_dist(const U& a, const V& b, int) const
     {
         ResultType result = ResultType();
-        ResultType ratio = (ResultType)(a / b);
-        if (ratio>0) {
-            result = a * log(ratio);
-        }
+        if( a != 0 && b != 0 ) {
+            ResultType ratio = (ResultType)(a / b);
+            if (ratio>0) {
+                result = a * log(ratio);
+            }
+		}
         return result;
     }
 };


### PR DESCRIPTION
accum_dist and operator() have to calculate the same way.
Fixed, assuming that operator() have the right code.
