### PR TITLE
Extend CenterChooser initialization

### DIFF
--- a/src/cpp/flann/algorithms/hierarchical_clustering_index.h
+++ b/src/cpp/flann/algorithms/hierarchical_clustering_index.h
@@ -128,6 +128,8 @@ public:
         initCenterChooser();
         
         setDataset(inputData);
+
+        chooseCenters_->setDataSize(veclen_);
     }
 
 


### PR DESCRIPTION
Large indizes might be saved to/loaded from a file.

However loading a `HierarchicalClusteringIndex` via `SavedIndexParams` does not call the `setDataSize` method. Hence the internal `cols_`  variable of `chooseCenters_` is uninitialized.

Trying to extend the index via `addPoints` then results in segmentation faults.
