### PR TITLE
Implement missing buildIndex(const Matrix<ElementType>& dataset) for KDT...

### DIFF
--- a/src/cpp/flann/algorithms/kdtree_cuda_3d_index.h
+++ b/src/cpp/flann/algorithms/kdtree_cuda_3d_index.h
@@ -137,6 +137,22 @@ public:
 
         uploadTreeToGpu();
     }
+	
+	/**
+	 * Builds the index using the specified dataset
+	 * @param dataset the dataset to use
+	 */
+    virtual void buildIndex(const Matrix<ElementType>& dataset)
+    {
+        dataset_ = dataset;
+        size_ = dataset_.rows;
+        dim_ = dataset_.cols;
+
+        int dim_param = get_param(index_params_,"dim",-1);
+        if (dim_param>0) dim_ = dim_param;
+		
+        this->buildIndex();
+    }
 
     flann_algorithm_t getType() const
     {
@@ -299,7 +315,7 @@ private:
 
     GpuHelper* gpu_helper_;
 
-    const Matrix<ElementType> dataset_;
+    Matrix<ElementType> dataset_;
 
     int leaf_max_size_;
 

--- a/src/cpp/flann/algorithms/nn_index.h
+++ b/src/cpp/flann/algorithms/nn_index.h
@@ -135,7 +135,7 @@ public:
 	}
 
 	/**
-	 * Builds th index using using the specified dataset
+	 * Builds the index using the specified dataset
 	 * @param dataset the dataset to use
 	 */
     virtual void buildIndex(const Matrix<ElementType>& dataset)


### PR DESCRIPTION
flann::KDTreeCuda3dIndexParams params;
params["input_is_gpu_float4"]=true;
//the following two lines work in current version
flann::Matrix<float> matrix_gpu(pointer_gpu, point_num, 3, 4*sizeof(float));
flann_index_.buildIndex(matrix_gpu);

// but not these two lines, due to the missing of buildIndex(const Matrix<ElementType>& dataset) in KDTreeCuda3dIndex class
//flann::Indexflann::L2<float > flannindex( params );
//flann_index_.buildIndex(matrix_gpu);

Also, on page 16 of the manual (http://www.cs.ubc.ca/research/flann/uploads/FLANN/flann_manual-1.8.4.pdf), the stride parameter should be 4*sizeof(float).
