### PR TITLE
Make search methods virtual.

### DIFF
--- a/src/cpp/flann/algorithms/nn_index.h
+++ b/src/cpp/flann/algorithms/nn_index.h
@@ -361,7 +361,7 @@ public:
      * @param params
      * @return
      */
-    int knnSearch(const Matrix<ElementType>& queries,
+    virtual int knnSearch(const Matrix<ElementType>& queries,
                                  Matrix<int>& indices,
                                  Matrix<DistanceType>& dists,
                                  size_t knn,


### PR DESCRIPTION
Otherwise, the search methods from derived classes can not be invoked by a pointer to the base class.
