### PR TITLE
Fixed build error on VS 2013

### DIFF
--- a/src/cpp/flann/util/serialization.h
+++ b/src/cpp/flann/util/serialization.h
@@ -107,7 +107,11 @@ BASIC_TYPE_SERIALIZER(float);
 BASIC_TYPE_SERIALIZER(double);
 BASIC_TYPE_SERIALIZER(bool);
 #ifdef _MSC_VER
+// unsigned __int64 ~= unsigned long long
+// Will throw error on VS2013
+#if _MSC_VER != 1800
 BASIC_TYPE_SERIALIZER(unsigned __int64);
+#endif
 #endif
 
 


### PR DESCRIPTION
unsigned __int64 ~= unsigned long long.  VS2013 will error.
