### PR TITLE
avoid build error in visual studio 2010 also

### DIFF
--- a/src/cpp/flann/util/serialization.h
+++ b/src/cpp/flann/util/serialization.h
@@ -107,9 +107,8 @@ BASIC_TYPE_SERIALIZER(float);
 BASIC_TYPE_SERIALIZER(double);
 BASIC_TYPE_SERIALIZER(bool);
 #ifdef _MSC_VER
-// unsigned __int64 ~= unsigned long long
-// Will throw error on VS2013
-#if _MSC_VER != 1800
+// unsigned __int64 != unsigned long long on some platforms
+#if _MSC_VER < 1600
 BASIC_TYPE_SERIALIZER(unsigned __int64);
 #endif
 #endif


### PR DESCRIPTION
The problem fixed by #210 on VS2013 also happens in VS2010. This makes it work at least with 64-bit targets on 2010; I don't have 2012, but I would imagine it's the same there, so I had it check for both of those.

I'm not sure about 32-bit targets; someone more knowledgeable about Visual Studio might be able to more fully determine what instances this is and isn't necessary in.
