### PR TITLE
Ignore list recommendation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,17 @@ dist/
 flann.kdev4
 TODO
 
+CMakeCache.txt
+CMakeFiles
+*.vcxproj
+*.filters
+*.sln
+*.suo
+*.pdb
+Win32
+*.tlog
+cmake_install.cmake
+*.obj
+uninstall_target.cmake
+*.sdf
+*.opensdf


### PR DESCRIPTION
Ignore list hides binary files for Windows users conducting in-source builds