### PR TITLE
Adding export keyword to ensure generation of static lib on Windows

### DIFF
--- a/src/cpp/flann/ext/lz4.c
+++ b/src/cpp/flann/ext/lz4.c
@@ -34,6 +34,11 @@
 //**************************************
 // Tuning parameters
 //**************************************
+#define DEFINE_LZ4_EXPORT
+
+//**************************************
+// Tuning parameters
+//**************************************
 // MEMORY_USAGE :
 // Memory usage formula : N->2^N Bytes (examples : 10 -> 1KB; 12 -> 4KB ; 16 -> 64KB; 20 -> 1MB; etc.)
 // Increasing memory usage improves compression ratio

--- a/src/cpp/flann/ext/lz4.h
+++ b/src/cpp/flann/ext/lz4.h
@@ -37,6 +37,16 @@
 extern "C" {
 #endif
 
+#if defined (_MSC_VER)
+#  if defined (DEFINE_LZ4_EXPORT)
+#    define LZ4_EXPORT_KEYWORD __declspec(dllexport)
+#  else
+#    define LZ4_EXPORT_KEYWORD __declspec(dllimport)
+#  endif
+#else
+#  define LZ4_EXPORT_KEYWORD
+#endif
+
 
 //**************************************
 // Compiler Options
@@ -106,7 +116,7 @@ LZ4_compress_limitedOutput() :
 */
 
 
-int LZ4_decompress_fast (const char* source, char* dest, int outputSize);
+int LZ4_EXPORT_KEYWORD LZ4_decompress_fast(const char* source, char* dest, int outputSize);
 
 /*
 LZ4_decompress_fast() :
@@ -119,7 +129,7 @@ LZ4_decompress_fast() :
            Destination buffer must be already allocated. Its size must be a minimum of 'outputSize' bytes.
 */
 
-int LZ4_decompress_safe_partial (const char* source, char* dest, int inputSize, int targetOutputSize, int maxOutputSize);
+int LZ4_EXPORT_KEYWORD LZ4_decompress_safe_partial(const char* source, char* dest, int inputSize, int targetOutputSize, int maxOutputSize);
 
 /*
 LZ4_decompress_safe_partial() :

--- a/src/cpp/flann/ext/lz4hc.c
+++ b/src/cpp/flann/ext/lz4hc.c
@@ -31,6 +31,8 @@
    - LZ4 source repository : http://code.google.com/p/lz4/
 */
 
+#define DEFINE_LZ4_EXPORT
+
 //**************************************
 // Memory routines
 //**************************************
@@ -39,7 +41,6 @@
 #define FREEMEM       free
 #include <string.h>   // memset, memcpy
 #define MEM_INIT      memset
-
 
 //**************************************
 // CPU Feature Detection

--- a/src/cpp/flann/ext/lz4hc.h
+++ b/src/cpp/flann/ext/lz4hc.h
@@ -38,8 +38,18 @@
 extern "C" {
 #endif
 
+#if defined (_MSC_VER)
+#  if defined (DEFINE_LZ4_EXPORT)
+#    define LZ4_EXPORT_KEYWORD __declspec(dllexport)
+#  else
+#    define LZ4_EXPORT_KEYWORD __declspec(dllimport)
+#  endif
+#else
+#  define LZ4_EXPORT_KEYWORD
+#endif
 
-int LZ4_compressHC (const char* source, char* dest, int inputSize);
+
+  int LZ4_EXPORT_KEYWORD LZ4_compressHC(const char* source, char* dest, int inputSize);
 /*
 LZ4_compressHC :
     return : the number of bytes in compressed buffer dest


### PR DESCRIPTION
On Mac and Linux, all symbols in a module that are not explicitly marked with private linkage will be present in the export table and availabel for linkage to other modules.  On Windows, however, the export address table requires affirmative membership, or it contains no entries.  If the linker detects that a binary module does not export any symbols, it will elide the generation of a static library.

Similarly, any symbol intended for use in an external module should be marked appropriately so that it will be inserted into the export table and also be compiled with the right linkage in the client module.  This PR shows an example of how this might be done for the LZ4 libraries.