### PR TITLE
MSVC minor patch

### DIFF
--- a/src/cpp/flann/algorithms/dist.h
+++ b/src/cpp/flann/algorithms/dist.h
@@ -108,14 +108,14 @@ struct L2_3D
     template <typename Iterator1, typename Iterator2>
     ResultType operator()(Iterator1 a, Iterator2 b, size_t size, ResultType /*worst_dist*/ = -1) const
     {
-        ResultType result = ResultType();        
+        ResultType result = ResultType();
         ResultType diff;
         diff = *a++ - *b++;
         result += diff*diff;
         diff = *a++ - *b++;
         result += diff*diff;
         diff = *a++ - *b++;
-        result += diff*diff;        
+        result += diff*diff;
         return result;
     }
 
@@ -477,6 +477,9 @@ struct HammingPopcnt
     ResultType operator()(Iterator1 a, Iterator2 b, size_t size, ResultType /*worst_dist*/ = -1) const
     {
         ResultType result = 0;
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+        typedef unsigned long long pop_t;
+#endif
 #if __GNUC__
 #if ANDROID && HAVE_NEON
         static uint64_t features = android_getCpuFeatures();

--- a/src/cpp/flann/util/serialization.h
+++ b/src/cpp/flann/util/serialization.h
@@ -108,8 +108,8 @@ BASIC_TYPE_SERIALIZER(double);
 BASIC_TYPE_SERIALIZER(bool);
 #ifdef _MSC_VER
 // unsigned __int64 ~= unsigned long long
-// Will throw error on VS2013
-#if _MSC_VER != 1800
+// Will throw error on VS2010 and VS2013
+#if _MSC_VER != 1600 && _MSC_VER != 1800
 BASIC_TYPE_SERIALIZER(unsigned __int64);
 #endif
 #endif


### PR DESCRIPTION
- *MSCV* does not define *pop_t* which is used in the *#else* part of *#if __GNUC__*
- *VC10.0* also considers *__int64* equivalent to *unsigned long long*