### PR TITLE
Merge addpoints bindings

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -3,6 +3,7 @@ The BSD License
 
 Copyright (c) 2008-2011  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.
 Copyright (c) 2008-2011  David G. Lowe (lowe@cs.ubc.ca). All rights reserved.
+Copyright (c) 2013  Abram Hindle (abram.hindle@ualberta.ca). All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/examples/example.py
+++ b/examples/example.py
@@ -1,0 +1,20 @@
+import pyflann
+from pyflann import *
+from numpy import *
+from numpy.random import *
+dataset = rand(1000, 128)
+testset = rand(100, 128)
+testset2 = rand(100, 128)
+flann = FLANN()
+params = flann.build_index(dataset, algorithm="kdtree")
+print params
+result, dists = flann.nn_index(testset,5, checks=params["checks"])
+
+flann.add_points( testset, 2 )
+
+result2, _ = flann.nn_index(testset,5, checks=params["checks"])
+
+print("Should be all over the place")
+print(",".join([str(r[0]) for r in result]))
+print("Should be between 1000 and 1100")
+print(",".join([str(r[0]) for r in result2]))

--- a/examples/example.py
+++ b/examples/example.py
@@ -1,20 +1,30 @@
 import pyflann
-from pyflann import *
-from numpy import *
-from numpy.random import *
-dataset = rand(1000, 128)
-testset = rand(100, 128)
-testset2 = rand(100, 128)
-flann = FLANN()
-params = flann.build_index(dataset, algorithm="kdtree")
-print params
-result, dists = flann.nn_index(testset,5, checks=params["checks"])
+import numpy as np
 
-flann.add_points( testset, 2 )
 
-result2, _ = flann.nn_index(testset,5, checks=params["checks"])
+def add_points_example():
+    dataset = np.random.rand(1000, 128)
+    testset = np.random.rand(100, 128)
+    #testset2 = np.random.rand(100, 128)
+    flann = pyflann.FLANN()
+    params = flann.build_index(dataset, algorithm="kdtree")
+    print('params = ' + str(params))
+    result1, dists = flann.nn_index(testset, 5, checks=params["checks"])
 
-print("Should be all over the place")
-print(",".join([str(r[0]) for r in result]))
-print("Should be between 1000 and 1100")
-print(",".join([str(r[0]) for r in result2]))
+    flann.add_points(testset, 2)
+
+    result2, _ = flann.nn_index(testset, 5, checks=params["checks"])
+
+    print("Should be all over the place")
+    print(",".join([str(r1[0]) for r1 in result1]))
+    print("Should be between 1000 and 1100")
+    print(",".join([str(r2[0]) for r2 in result2]))
+    assert np.all(result2.T[0] >= 1000), 'new points should be found first'
+    assert (result2.T[1] == result1.T[0]).sum() > result1.shape[0] / 2, 'most old points should be found next'
+
+if __name__ == '__main__':
+    """
+    CommandLine:
+        python examples/example.py
+    """
+    add_points_example()

--- a/src/cpp/flann/flann.cpp
+++ b/src/cpp/flann/flann.cpp
@@ -290,7 +290,7 @@ flann_index_t flann_build_index_int(int* dataset, int rows, int cols, float* spe
 
 // Add Points Begin
 template<typename Distance>
-void __flann_add_points(flann_index_t index_ptr,  typename Distance::ElementType* dataset, int rows, int cols, int rebuild_threshhold)
+void __flann_add_points(flann_index_t index_ptr,  typename Distance::ElementType* dataset, int rows, int rebuild_threshhold)
 {
     typedef typename Distance::ElementType ElementType;
     try {
@@ -299,7 +299,7 @@ void __flann_add_points(flann_index_t index_ptr,  typename Distance::ElementType
         }
 
         Index<Distance>* index = (Index<Distance>*)index_ptr;
-        index->addPoints(Matrix<ElementType>(dataset,rows,cols), rebuild_threshhold);
+        index->addPoints(Matrix<ElementType>(dataset,rows,index->veclen()), rebuild_threshhold);
         return;
     }
     catch (std::runtime_error& e) {
@@ -309,53 +309,53 @@ void __flann_add_points(flann_index_t index_ptr,  typename Distance::ElementType
 }
 
 template<typename T>
-void _flann_add_points(flann_index_t index_ptr, T* dataset, int rows, int cols, int rebuild_threshold)
+void _flann_add_points(flann_index_t index_ptr, T* dataset, int rows, int rebuild_threshold)
 {
     if (flann_distance_type==FLANN_DIST_EUCLIDEAN) {
-         __flann_add_points<L2<T> >(index_ptr, dataset, rows, cols, rebuild_threshold);
+         __flann_add_points<L2<T> >(index_ptr, dataset, rows, rebuild_threshold);
     }
     else if (flann_distance_type==FLANN_DIST_MANHATTAN) {
-         __flann_add_points<L1<T> >(index_ptr, dataset, rows, cols, rebuild_threshold);
+         __flann_add_points<L1<T> >(index_ptr, dataset, rows, rebuild_threshold);
     }
     else if (flann_distance_type==FLANN_DIST_MINKOWSKI) {
-       __flann_add_points<MinkowskiDistance<T> >(index_ptr, dataset, rows, cols, rebuild_threshold);
+       __flann_add_points<MinkowskiDistance<T> >(index_ptr, dataset, rows, rebuild_threshold);
     }
     else if (flann_distance_type==FLANN_DIST_HIST_INTERSECT) {
-         __flann_add_points<HistIntersectionDistance<T> >(index_ptr, dataset, rows, cols, rebuild_threshold);
+         __flann_add_points<HistIntersectionDistance<T> >(index_ptr, dataset, rows, rebuild_threshold);
     }
     else if (flann_distance_type==FLANN_DIST_HELLINGER) {
-         __flann_add_points<HellingerDistance<T> >(index_ptr, dataset, rows, cols, rebuild_threshold);
+         __flann_add_points<HellingerDistance<T> >(index_ptr, dataset, rows, rebuild_threshold);
     }
     else if (flann_distance_type==FLANN_DIST_CHI_SQUARE) {
-         __flann_add_points<ChiSquareDistance<T> >(index_ptr, dataset, rows, cols, rebuild_threshold);
+         __flann_add_points<ChiSquareDistance<T> >(index_ptr, dataset, rows, rebuild_threshold);
     }
     else if (flann_distance_type==FLANN_DIST_KULLBACK_LEIBLER) {
-         __flann_add_points<KL_Divergence<T> >(index_ptr, dataset, rows, cols, rebuild_threshold);
+         __flann_add_points<KL_Divergence<T> >(index_ptr, dataset, rows, rebuild_threshold);
     }
     else {
         Logger::error( "Distance type unsupported in the C bindings, use the C++ bindings instead\n");
     }
 }
 
-void flann_add_points(flann_index_t index_ptr, float* dataset, int rows, int cols, int rebuild_threshhold)
+void flann_add_points(flann_index_t index_ptr, float* dataset, int rows, int rebuild_threshhold)
 {
-    _flann_add_points<float>(index_ptr, dataset, rows, cols, rebuild_threshhold);
+    _flann_add_points<float>(index_ptr, dataset, rows, rebuild_threshhold);
 }
-void flann_add_points_float(flann_index_t index_ptr, float* dataset, int rows, int cols, int rebuild_threshhold)
+void flann_add_points_float(flann_index_t index_ptr, float* dataset, int rows, int rebuild_threshhold)
 {
-    _flann_add_points<float>(index_ptr, dataset, rows, cols, rebuild_threshhold);
+    _flann_add_points<float>(index_ptr, dataset, rows, rebuild_threshhold);
 }
-void flann_add_points_double(flann_index_t index_ptr, double* dataset, int rows, int cols, int rebuild_threshhold)
+void flann_add_points_double(flann_index_t index_ptr, double* dataset, int rows, int rebuild_threshhold)
 {
-    _flann_add_points<double>(index_ptr, dataset, rows, cols, rebuild_threshhold);
+    _flann_add_points<double>(index_ptr, dataset, rows, rebuild_threshhold);
 }
-void flann_add_points_byte(flann_index_t index_ptr, unsigned char* dataset, int rows, int cols, int rebuild_threshhold)
+void flann_add_points_byte(flann_index_t index_ptr, unsigned char* dataset, int rows, int rebuild_threshhold)
 {
-    _flann_add_points<unsigned char>(index_ptr, dataset, rows, cols, rebuild_threshhold);
+    _flann_add_points<unsigned char>(index_ptr, dataset, rows, rebuild_threshhold);
 }
-void flann_add_points_int(flann_index_t index_ptr, int* dataset, int rows, int cols, int rebuild_threshhold)
+void flann_add_points_int(flann_index_t index_ptr, int* dataset, int rows, int rebuild_threshhold)
 {
-    _flann_add_points<int>(index_ptr, dataset, rows, cols, rebuild_threshhold);
+    _flann_add_points<int>(index_ptr, dataset, rows, rebuild_threshhold);
 }
 
 

--- a/src/cpp/flann/flann.cpp
+++ b/src/cpp/flann/flann.cpp
@@ -288,6 +288,80 @@ flann_index_t flann_build_index_int(int* dataset, int rows, int cols, float* spe
     return _flann_build_index<int>(dataset, rows, cols, speedup, flann_params);
 }
 
+// Add Points Begin
+template<typename Distance>
+void __flann_add_points(flann_index_t index_ptr,  typename Distance::ElementType* dataset, int rows, int cols, int rebuild_threshhold)
+{
+    typedef typename Distance::ElementType ElementType;
+    try {
+        if (index_ptr==NULL) {
+            throw FLANNException("Invalid index");
+        }
+
+        Index<Distance>* index = (Index<Distance>*)index_ptr;
+        index->addPoints(Matrix<ElementType>(dataset,rows,cols), rebuild_threshhold);
+        return;
+    }
+    catch (std::runtime_error& e) {
+        Logger::error("Caught exception: %s\n",e.what());
+        return;
+    }
+}
+
+template<typename T>
+void _flann_add_points(flann_index_t index_ptr, T* dataset, int rows, int cols, int rebuild_threshold)
+{
+    if (flann_distance_type==FLANN_DIST_EUCLIDEAN) {
+         __flann_add_points<L2<T> >(index_ptr, dataset, rows, cols, rebuild_threshold);
+    }
+    else if (flann_distance_type==FLANN_DIST_MANHATTAN) {
+         __flann_add_points<L1<T> >(index_ptr, dataset, rows, cols, rebuild_threshold);
+    }
+    else if (flann_distance_type==FLANN_DIST_MINKOWSKI) {
+       __flann_add_points<MinkowskiDistance<T> >(index_ptr, dataset, rows, cols, rebuild_threshold);
+    }
+    else if (flann_distance_type==FLANN_DIST_HIST_INTERSECT) {
+         __flann_add_points<HistIntersectionDistance<T> >(index_ptr, dataset, rows, cols, rebuild_threshold);
+    }
+    else if (flann_distance_type==FLANN_DIST_HELLINGER) {
+         __flann_add_points<HellingerDistance<T> >(index_ptr, dataset, rows, cols, rebuild_threshold);
+    }
+    else if (flann_distance_type==FLANN_DIST_CHI_SQUARE) {
+         __flann_add_points<ChiSquareDistance<T> >(index_ptr, dataset, rows, cols, rebuild_threshold);
+    }
+    else if (flann_distance_type==FLANN_DIST_KULLBACK_LEIBLER) {
+         __flann_add_points<KL_Divergence<T> >(index_ptr, dataset, rows, cols, rebuild_threshold);
+    }
+    else {
+        Logger::error( "Distance type unsupported in the C bindings, use the C++ bindings instead\n");
+    }
+}
+
+void flann_add_points(flann_index_t index_ptr, float* dataset, int rows, int cols, int rebuild_threshhold)
+{
+    _flann_add_points<float>(index_ptr, dataset, rows, cols, rebuild_threshhold);
+}
+void flann_add_points_float(flann_index_t index_ptr, float* dataset, int rows, int cols, int rebuild_threshhold)
+{
+    _flann_add_points<float>(index_ptr, dataset, rows, cols, rebuild_threshhold);
+}
+void flann_add_points_double(flann_index_t index_ptr, double* dataset, int rows, int cols, int rebuild_threshhold)
+{
+    _flann_add_points<double>(index_ptr, dataset, rows, cols, rebuild_threshhold);
+}
+void flann_add_points_byte(flann_index_t index_ptr, unsigned char* dataset, int rows, int cols, int rebuild_threshhold)
+{
+    _flann_add_points<unsigned char>(index_ptr, dataset, rows, cols, rebuild_threshhold);
+}
+void flann_add_points_int(flann_index_t index_ptr, int* dataset, int rows, int cols, int rebuild_threshhold)
+{
+    _flann_add_points<int>(index_ptr, dataset, rows, cols, rebuild_threshhold);
+}
+
+
+// Add Points END
+
+
 template<typename Distance>
 int __flann_save_index(flann_index_t index_ptr, char* filename)
 {

--- a/src/cpp/flann/flann.h
+++ b/src/cpp/flann/flann.h
@@ -171,28 +171,23 @@ FLANN_EXPORT flann_index_t flann_build_index_int(int* dataset,
 
 FLANN_EXPORT void flann_add_points(flann_index_t index_id, float* dataset,
                                              int rows,
-                                             int cols,
                                              int rebuild_threshold);
 
 
 FLANN_EXPORT void flann_add_points_float(flann_index_t index_id, float* dataset,
                                              int rows,
-                                             int cols,
                                              int rebuild_threshold);
 
 FLANN_EXPORT void flann_add_points_double(flann_index_t index_id, double* dataset,
                                              int rows,
-                                             int cols,
                                              int rebuild_threshold);
 
 FLANN_EXPORT void flann_add_points_int(flann_index_t index_id, int* dataset,
                                              int rows,
-                                             int cols,
                                              int rebuild_threshold);
 
 FLANN_EXPORT void flann_add_points_byte(flann_index_t index_id, unsigned char* dataset,
                                              int rows,
-                                             int cols,
                                              int rebuild_threshold);
 
 

--- a/src/cpp/flann/flann.h
+++ b/src/cpp/flann/flann.h
@@ -93,6 +93,8 @@ FLANN_EXPORT extern struct FLANNParameters DEFAULT_FLANN_PARAMETERS;
 FLANN_EXPORT void flann_log_verbosity(int level);
 
 
+
+
 /**
  * Sets the distance type to use throughout FLANN.
  * If distance type specified is MINKOWSKI, the second argument
@@ -154,6 +156,47 @@ FLANN_EXPORT flann_index_t flann_build_index_int(int* dataset,
                                                  int cols,
                                                  float* speedup,
                                                  struct FLANNParameters* flann_params);
+/**
+   Adds points to an index.
+
+   Params:
+    index_id The index that should be modified
+    dataset = pointer to a data set stored in row major order
+    rows = number of rows (features) in the dataset
+    cols = number of columns in the dataset (feature dimensionality)
+    rebuild_threadhold
+
+   Returns: void
+ */
+
+FLANN_EXPORT void flann_add_points(flann_index_t index_id, float* dataset,
+                                             int rows,
+                                             int cols,
+                                             int rebuild_threshold);
+
+
+FLANN_EXPORT void flann_add_points_float(flann_index_t index_id, float* dataset,
+                                             int rows,
+                                             int cols,
+                                             int rebuild_threshold);
+
+FLANN_EXPORT void flann_add_points_double(flann_index_t index_id, double* dataset,
+                                             int rows,
+                                             int cols,
+                                             int rebuild_threshold);
+
+FLANN_EXPORT void flann_add_points_int(flann_index_t index_id, int* dataset,
+                                             int rows,
+                                             int cols,
+                                             int rebuild_threshold);
+
+FLANN_EXPORT void flann_add_points_byte(flann_index_t index_id, unsigned char* dataset,
+                                             int rows,
+                                             int cols,
+                                             int rebuild_threshold);
+
+
+
 
 /**
  * Saves the index to a file. Only the index is saved into the file, the dataset corresponding to the index is not saved.

--- a/src/python/pyflann/flann_ctypes.py
+++ b/src/python/pyflann/flann_ctypes.py
@@ -225,6 +225,21 @@ flannlib.flann_build_index_%(C)s.argtypes = [
 flann.build_index[%(numpy)s] = flannlib.flann_build_index_%(C)s
 """)
 
+flann.add_points = {}
+define_functions(r"""
+flannlib.flann_add_points_%(C)s.restype = None
+flannlib.flann_add_points_%(C)s.argtypes = [ 
+        FLANN_INDEX, # index_id
+        ndpointer(%(numpy)s, ndim = 2, flags='aligned, c_contiguous'), # dataset
+        c_int, # rows
+        c_int, # cols
+        c_int, # rebuild_threshhold
+]
+flann.add_points[%(numpy)s] = flannlib.flann_add_points_%(C)s
+""")
+
+
+
 flann.save_index = {}
 define_functions(r"""
 flannlib.flann_save_index_%(C)s.restype = None

--- a/src/python/pyflann/index.py
+++ b/src/python/pyflann/index.py
@@ -33,12 +33,12 @@ index_type = int32
 
 def set_distance_type(distance_type, order = 0):
     """
-    Sets the distance type used. Possible values: euclidean, manhattan, minkowski, max_dist, 
+    Sets the distance type used. Possible values: euclidean, manhattan, minkowski, max_dist,
     hik, hellinger, cs, kl.
     """
-    
-    distance_translation = { "euclidean" : 1, 
-                            "manhattan" : 2, 
+
+    distance_translation = { "euclidean" : 1,
+                            "manhattan" : 2,
                             "minkowski" : 3,
                             "max_dist" : 4,
                             "hik" : 5,
@@ -66,7 +66,7 @@ class FLANN:
     This class defines a python interface to the FLANN lirary.
     """
     __rn_gen = _rn.RandomState()
-    
+
     _as_parameter_ = property( lambda self: self.__curindex )
 
     def __init__(self, **kwargs):
@@ -75,20 +75,20 @@ class FLANN:
         the flann libraries.  Any keyword arguments passed to __init__
         override the global defaults given.
         """
-        
+
         self.__rn_gen.seed()
 
         self.__curindex = None
         self.__curindex_data = None
         self.__curindex_type = None
-        
-        self.__flann_parameters = FLANNParameters()        
+
+        self.__flann_parameters = FLANNParameters()
         self.__flann_parameters.update(kwargs)
 
     def __del__(self):
         self.delete_index()
 
-        
+
     ################################################################################
     # actual workhorse functions
 
@@ -97,7 +97,7 @@ class FLANN:
         Returns the num_neighbors nearest points in dataset for each point
         in testset.
         """
-        
+
         if not pts.dtype.type in allowed_types:
             raise FLANNException("Cannot handle type: %s"%pts.dtype)
 
@@ -106,9 +106,9 @@ class FLANN:
 
         if pts.dtype != qpts.dtype:
             raise FLANNException("Data and query must have the same type")
-        
-        pts = ensure_2d_array(pts,default_flags) 
-        qpts = ensure_2d_array(qpts,default_flags) 
+
+        pts = ensure_2d_array(pts,default_flags)
+        qpts = ensure_2d_array(qpts,default_flags)
 
         npts, dim = pts.shape
         nqpts = qpts.shape[0]
@@ -121,11 +121,11 @@ class FLANN:
             dists = empty( (nqpts, num_neighbors), dtype=float64)
         else:
             dists = empty( (nqpts, num_neighbors), dtype=float32)
-                
+
         self.__flann_parameters.update(kwargs)
 
-        flann.find_nearest_neighbors[pts.dtype.type](pts, npts, dim, 
-                                                     qpts, nqpts, result, dists, num_neighbors, 
+        flann.find_nearest_neighbors[pts.dtype.type](pts, npts, dim,
+                                                     qpts, nqpts, result, dists, num_neighbors,
                                                      pointer(self.__flann_parameters))
 
         if num_neighbors == 1:
@@ -144,39 +144,44 @@ class FLANN:
 
         pts is a 2d numpy array or matrix. All the computation is done
         in float32 type, but pts may be any type that is convertable
-        to float32. 
+        to float32.
         """
-        
+
         if not pts.dtype.type in allowed_types:
             raise FLANNException("Cannot handle type: %s"%pts.dtype)
 
-        pts = ensure_2d_array(pts,default_flags) 
+        pts = ensure_2d_array(pts,default_flags)
         npts, dim = pts.shape
-        
+
         self.__ensureRandomSeed(kwargs)
-        
+
         self.__flann_parameters.update(kwargs)
 
         if self.__curindex != None:
             flann.free_index[self.__curindex_type](self.__curindex, pointer(self.__flann_parameters))
             self.__curindex = None
-                
+
         speedup = c_float(0)
         self.__curindex = flann.build_index[pts.dtype.type](pts, npts, dim, byref(speedup), pointer(self.__flann_parameters))
         self.__curindex_data = pts
         self.__curindex_type = pts.dtype.type
-        
+
         params = dict(self.__flann_parameters)
         params["speedup"] = speedup.value
-        
+
         return params
 
     def add_points(self, pts, rebuild_threshold=2):
-        if not pts.dtype.type in allowed_types:
-            raise FLANNException("Cannot handle type: %s"%pts.dtype)
-        pts = ensure_2d_array(pts,default_flags) 
-        npts, dim = pts.shape
-        flann.add_points[self.__curindex_type](self.__curindex, pts, npts, dim, rebuild_threshold)
+        """
+        Adds pts to the current index. If the number of added points is more
+        than a factor of rebuild_threshold larger than the original number of
+        points, the index is rebuilt.
+        """
+        if pts.dtype.type not in allowed_types:
+            raise FLANNException("Cannot handle type: %s" % pts.dtype)
+        pts = ensure_2d_array(pts, default_flags)
+        rows = pts.shape[0]
+        flann.add_points[self.__curindex_type](self.__curindex, pts, rows, rebuild_threshold)
 
     def save_index(self, filename):
         """
@@ -189,11 +194,11 @@ class FLANN:
         """
         Loads an index previously saved to disk.
         """
-                
+
         if not pts.dtype.type in allowed_types:
             raise FLANNException("Cannot handle type: %s"%pts.dtype)
 
-        pts = ensure_2d_array(pts,default_flags) 
+        pts = ensure_2d_array(pts,default_flags)
         npts, dim = pts.shape
 
         if self.__curindex != None:
@@ -201,7 +206,7 @@ class FLANN:
             self.__curindex = None
             self.__curindex_data = None
             self.__curindex_type = None
-        
+
         self.__curindex = flann.load_index[pts.dtype.type](c_char_p(to_bytes(filename)), pts, npts, dim)
         self.__curindex_data = pts
         self.__curindex_type = pts.dtype.type
@@ -222,7 +227,7 @@ class FLANN:
         if self.__curindex_type != qpts.dtype.type:
             raise FLANNException("Index and query must have the same type")
 
-        qpts = ensure_2d_array(qpts,default_flags) 
+        qpts = ensure_2d_array(qpts,default_flags)
 
         npts, dim = self.__curindex_data.shape
 
@@ -233,7 +238,7 @@ class FLANN:
 
         assert(qpts.shape[1] == dim)
         assert(npts >= num_neighbors)
-        
+
         result = empty( (nqpts, num_neighbors), dtype=index_type)
         if self.__curindex_type==float64:
             dists = empty( (nqpts, num_neighbors), dtype=float64)
@@ -242,7 +247,7 @@ class FLANN:
 
         self.__flann_parameters.update(kwargs)
 
-        flann.find_nearest_neighbors_index[self.__curindex_type](self.__curindex, 
+        flann.find_nearest_neighbors_index[self.__curindex_type](self.__curindex,
                     qpts, nqpts,
                     result, dists, num_neighbors,
                     pointer(self.__flann_parameters))
@@ -251,10 +256,10 @@ class FLANN:
             return (result.reshape( nqpts ), dists.reshape( nqpts ))
         else:
             return (result,dists)
-        
-        
+
+
     def nn_radius(self, query, radius, **kwargs):
-        
+
         if self.__curindex == None:
             raise FLANNException("build_index(...) method not called first or current index deleted.")
 
@@ -264,32 +269,32 @@ class FLANN:
         if self.__curindex_type != query.dtype.type:
             raise FLANNException("Index and query must have the same type")
 
-        npts, dim = self.__curindex_data.shape        
+        npts, dim = self.__curindex_data.shape
         assert(query.shape[0]==dim)
-        
+
         result = empty( npts, dtype=index_type)
         if self.__curindex_type==float64:
             dists = empty( npts, dtype=float64)
         else:
             dists = empty( npts, dtype=float32)
-        
+
         self.__flann_parameters.update(kwargs)
 
-        nn = flann.radius_search[self.__curindex_type](self.__curindex, query, 
+        nn = flann.radius_search[self.__curindex_type](self.__curindex, query,
                                          result, dists, npts,
                                          radius, pointer(self.__flann_parameters))
-        
-        
+
+
         return (result[0:nn],dists[0:nn])
 
     def delete_index(self, **kwargs):
         """
-        Deletes the current index freeing all the momory it uses. 
+        Deletes the current index freeing all the momory it uses.
         The memory used by the dataset that was indexed is not freed.
         """
 
         self.__flann_parameters.update(kwargs)
-        
+
         if self.__curindex != None:
             flann.free_index[self.__curindex_type](self.__curindex, pointer(self.__flann_parameters))
             self.__curindex = None
@@ -302,47 +307,47 @@ class FLANN:
                dtype = None, **kwargs):
         """
         Runs kmeans on pts with num_clusters centroids.  Returns a
-        numpy array of size num_clusters x dim.  
+        numpy array of size num_clusters x dim.
 
         If max_iterations is not None, the algorithm terminates after
         the given number of iterations regardless of convergence.  The
         default is to run until convergence.
 
         If dtype is None (the default), the array returned is the same
-        type as pts.  Otherwise, the returned array is of type dtype.  
+        type as pts.  Otherwise, the returned array is of type dtype.
 
         """
-        
+
         if int(num_clusters) != num_clusters or num_clusters < 1:
             raise FLANNException('num_clusters must be an integer >= 1')
-        
+
         if num_clusters == 1:
             if dtype == None or dtype == pts.dtype:
                 return mean(pts, 0).reshape(1, pts.shape[1])
             else:
                 return dtype(mean(pts, 0).reshape(1, pts.shape[1]))
 
-        return self.hierarchical_kmeans(pts, int(num_clusters), 1, 
-                                        max_iterations, 
+        return self.hierarchical_kmeans(pts, int(num_clusters), 1,
+                                        max_iterations,
                                         dtype, **kwargs)
-        
+
     def hierarchical_kmeans(self, pts, branch_size, num_branches,
-                            max_iterations = None, 
+                            max_iterations = None,
                             dtype = None, **kwargs):
         """
         Clusters the data by using multiple runs of kmeans to
         recursively partition the dataset.  The number of resulting
         clusters is given by (branch_size-1)*num_branches+1.
-        
+
         This method can be significantly faster when the number of
         desired clusters is quite large (e.g. a hundred or more).
         Higher branch sizes are slower but may give better results.
 
         If dtype is None (the default), the array returned is the same
-        type as pts.  Otherwise, the returned array is of type dtype.  
-        
+        type as pts.  Otherwise, the returned array is of type dtype.
+
         """
-        
+
         # First verify the paremeters are sensible.
 
         if not pts.dtype.type in allowed_types:
@@ -358,35 +363,35 @@ class FLANN:
 
         num_branches = int(num_branches)
 
-        if max_iterations == None: 
+        if max_iterations == None:
             max_iterations = -1
         else:
             max_iterations = int(max_iterations)
 
 
         # init the arrays and starting values
-        pts = ensure_2d_array(pts,default_flags) 
+        pts = ensure_2d_array(pts,default_flags)
         npts, dim = pts.shape
         num_clusters = (branch_size-1)*num_branches+1;
-        
+
         if pts.dtype.type == float64:
             result = empty( (num_clusters, dim), dtype=float64)
         else:
             result = empty( (num_clusters, dim), dtype=float32)
 
         # set all the parameters appropriately
-        
+
         self.__ensureRandomSeed(kwargs)
-        
+
         params = {"iterations"       : max_iterations,
                     "algorithm"        : 'kmeans',
                     "branching"        : branch_size,
                     "random_seed"      : kwargs['random_seed']}
-        
+
         self.__flann_parameters.update(params)
-        
+
         numclusters = flann.compute_cluster_centers[pts.dtype.type](pts, npts, dim,
-                                        num_clusters, result, 
+                                        num_clusters, result,
                                         pointer(self.__flann_parameters))
         if numclusters <= 0:
             raise FLANNException('Error occured during clustering procedure.')
@@ -395,14 +400,14 @@ class FLANN:
             return result
         else:
             return dtype(result)
-        
+
     ##########################################################################################
     # internal bookkeeping functions
 
-        
+
     def __ensureRandomSeed(self, kwargs):
         if not 'random_seed' in kwargs:
             kwargs['random_seed'] = self.__rn_gen.randint(2**30)
-        
+
 
 

--- a/src/python/pyflann/index.py
+++ b/src/python/pyflann/index.py
@@ -171,6 +171,12 @@ class FLANN:
         
         return params
 
+    def add_points(self, pts, rebuild_threshold=2):
+        if not pts.dtype.type in allowed_types:
+            raise FLANNException("Cannot handle type: %s"%pts.dtype)
+        pts = ensure_2d_array(pts,default_flags) 
+        npts, dim = pts.shape
+        flann.add_points[self.__curindex_type](self.__curindex, pts, npts, dim, rebuild_threshold)
 
     def save_index(self, filename):
         """


### PR DESCRIPTION
This is another request to merge the add_point bindings described in the following:

https://github.com/mariusmuja/flann/pull/93
https://github.com/mariusmuja/flann/pull/123
https://github.com/mariusmuja/flann/pull/124

I continued work on the original commit so the original author can receive credit. 

However, I think this needs more work before it is is merged because there may be 
dangerous memory allocation happening that could cause segfaults. I've seen segfaults in 
some of my more complex code that uses these bindings. I've been unable to reproduce the segfaults in simpler examples though, so this code might be fine to merge. 

I'm not a C++ expert, so it'd be nice if someone with more expertise could help. 

When the original flann index is created a numpy array is passed to the build index function as a block of contiguous memory. 

When the add points function is called another chunk of contiguous memory is effectively sent to the extendDataset function in src/cpp/flann/algorithms/nn_index.h

This causes a resize of the member variable std::vector<ElementType*> points_ to be resized. 

I'm not sure how the numpy.ndarray gets into the points_ it seems setDataset in nn_index.h will copy all of the points from the ndarray into flanns own internal structure. If this is true then if any of the numpy.ndarrays are garbage collected the underlying flann points_ data should be fine, and no Segfaults should occur. 

Any input would be appreciated, and it if seems that these bindings do work correctly then I believe they should be merged into the master branch. 