### PR TITLE
fix constructor and deconstructor of the KDTreeIndex::Node. 

### DIFF
--- a/src/cpp/flann/algorithms/kdtree_index.h
+++ b/src/cpp/flann/algorithms/kdtree_index.h
@@ -299,15 +299,19 @@ private:
          * Point data
          */
         ElementType* point;
-        /**
-         * The child nodes.
-         */
-        Node* child1, * child2;
+		/**
+		* The child nodes.
+		*/
+		Node* child1, *child2;
+		Node(){
+			child1 = NULL;
+			child2 = NULL;
+		}
+		~Node() {
+			if (child1 != NULL) { child1->~Node(); child1 = NULL; }
 
-        ~Node() {
-        	if (child1!=NULL) child1->~Node();
-        	if (child2!=NULL) child2->~Node();
-        }
+			if (child2 != NULL) { child2->~Node(); child2 = NULL; }
+		}
 
     private:
     	template<typename Archive>


### PR DESCRIPTION
This will cause the serialization work incorrectly in the case of the debug version and when the child pointer is not initialized as NULL automatically.

Because in saving node, serilazation relies on leaf_node = ((child1==NULL) && (child2==NULL)) to determine whether it's leaf or not.