### PR TITLE
result_set bugfix

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -3,6 +3,7 @@ The BSD License
 
 Copyright (c) 2008-2011  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.
 Copyright (c) 2008-2011  David G. Lowe (lowe@cs.ubc.ca). All rights reserved.
+Copyright (c) 2015       Google Inc (Jack Rae, jwrae@google.com). All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/src/cpp/flann/util/result_set.h
+++ b/src/cpp/flann/util/result_set.h
@@ -252,12 +252,10 @@ public:
 #endif
             {
                 // Check for duplicate indices
-                size_t j = i - 1;
-                while (dist_index_[j].dist_ == dist) {
+                for (size_t j = i - 1; dist_index_[j].dist_ == dist && j--;) {
                     if (dist_index_[j].index_ == index) {
                         return;
                     }
-                    --j;
                 }
                 break;
             }


### PR DESCRIPTION
Zero-based boundary condition is not enforced for the variable size_t j,
it was previously free to underflow.

I have placed j-- as a condition within the for loop to enforce this.
See this
thread for considerations on good style for decrementing size_t loops:
http://stackoverflow.com/questions/7224386/iterating-with-size-t-0-as-a-boundary-condition

Placing the j-- at the beginning of the loop is equivalent to --j at the
end, so the functionality is identical.

Updated COPYING as this is standard / mandatory practice for Google employees'
contributions to open source projects.