### PR TITLE
Added new python bindings with associated unit tests. 

### DIFF
--- a/src/cpp/flann/flann.h
+++ b/src/cpp/flann/flann.h
@@ -156,6 +156,79 @@ FLANN_EXPORT flann_index_t flann_build_index_int(int* dataset,
                                                  struct FLANNParameters* flann_params);
 
 /**
+    Returns the amount of memory used by the index
+
+    Returns: int
+ */
+
+FLANN_EXPORT int flann_used_memory(flann_index_t index_ptr);
+
+FLANN_EXPORT int flann_used_memory_float(flann_index_t index_ptr);
+
+FLANN_EXPORT int flann_used_memory_double(flann_index_t index_ptr);
+
+FLANN_EXPORT int flann_used_memory_int(flann_index_t index_ptr);
+
+FLANN_EXPORT int flann_used_memory_byte(flann_index_t index_ptr);
+
+
+/**
+   Adds points to an index.
+
+   Params:
+    index_id The index that should be modified
+    dataset = pointer to a data set stored in row major order
+    rows = number of rows (features) in the dataset
+    cols = number of columns in the dataset (feature dimensionality)
+    rebuild_threadhold
+
+   Returns: void
+ */
+
+FLANN_EXPORT void flann_add_points(flann_index_t index_id, float* dataset,
+                                             int rows,
+                                             int rebuild_threshold);
+
+
+FLANN_EXPORT void flann_add_points_float(flann_index_t index_id, float* dataset,
+                                             int rows,
+                                             int rebuild_threshold);
+
+FLANN_EXPORT void flann_add_points_double(flann_index_t index_id, double* dataset,
+                                             int rows,
+                                             int rebuild_threshold);
+
+FLANN_EXPORT void flann_add_points_int(flann_index_t index_id, int* dataset,
+                                             int rows,
+                                             int rebuild_threshold);
+
+FLANN_EXPORT void flann_add_points_byte(flann_index_t index_id, unsigned char* dataset,
+                                             int rows,
+                                             int rebuild_threshold);
+
+
+/**
+    Removes a point from the index
+
+    Params:
+        index_id The index that should be modified
+        id = point id to be removed
+
+    Returns: void
+*/
+
+FLANN_EXPORT void flann_remove_point(flann_index_t index_ptr, int id_);
+
+FLANN_EXPORT void flann_remove_point_float(flann_index_t index_ptr, int id_);
+
+FLANN_EXPORT void flann_remove_point_double(flann_index_t index_ptr, int id_);
+
+FLANN_EXPORT void flann_remove_point_int(flann_index_t index_ptr, int id_);
+
+FLANN_EXPORT void flann_remove_point_byte(flann_index_t index_ptr, int id_);
+
+
+/**
  * Saves the index to a file. Only the index is saved into the file, the dataset corresponding to the index is not saved.
  *
  * @param index_id The index that should be saved

--- a/src/python/pyflann/index.py
+++ b/src/python/pyflann/index.py
@@ -88,14 +88,47 @@ class FLANN(object):
         self.__rn_gen.seed()
 
         self.__curindex = None
-        self.__curindex_data = None
+        self.__curindex_data = None  # pointer to keep the numpy data alive
+        self.__added_data = []  # contained to keep any added numpy data alive
         self.__curindex_type = None
 
         self.__flann_parameters = FLANNParameters()
         self.__flann_parameters.update(kwargs)
 
     def __del__(self):
+        #print('FLANN OBJECT IS DELETED')
         self.delete_index()
+
+    def get_indexed_shape(self):
+        npts, dim = self.__curindex_data.shape
+        for _extra in self.__added_data:
+            npts += _extra.shape[0]
+        return npts, dim
+
+    def get_indexed_data(self):
+        """ returns all the data indexed by the FLANN object """
+        return self.__curindex_data, self.__added_data
+
+    def used_memory_dataset(self):
+        """
+        Returns the amount of memory used by the dataset
+        """
+        if self.__curindex_data is None:
+            return 0
+        num_bytes = self.__curindex_data.nbytes
+        for _extra in self.__added_data:
+            num_bytes += _extra.nbytes
+        return num_bytes
+
+    def used_memory(self):
+        """
+        Returns the amount of memory used by the index
+
+        Returns: int
+        """
+        if self.__curindex is None:
+            return 0
+        return flann.used_memory[self.__curindex_type](self.__curindex)
 
     ##########################################################################
     # actual workhorse functions
@@ -181,6 +214,65 @@ class FLANN(object):
 
         return params
 
+    def add_points(self, new_pts, rebuild_threshold=2):
+        """
+        Adds pts to the current index. If the number of added points is more
+        than a factor of rebuild_threshold larger than the original number of
+        points, the index is rebuilt.
+        """
+        if new_pts.dtype.type not in allowed_types:
+            raise FLANNException('Cannot handle type: %s' % new_pts.dtype)
+        if new_pts.dtype != self.__curindex_type:
+            raise FLANNException('New points must have the same type')
+        new_pts = ensure_2d_array(new_pts, default_flags)
+        rows = new_pts.shape[0]
+        flann.add_points[self.__curindex_type](self.__curindex, new_pts, rows, rebuild_threshold)
+        self.__added_data.append(new_pts)
+
+    def remove_point(self, id_):
+        """
+        Removes a point from the index
+
+        Params:
+            id = point id to be removed
+
+        Returns: void
+        """
+        flann.remove_point[self.__curindex_type](self.__curindex, id_)
+
+    def remove_points(self, id_list):
+        """
+        Removes multiple points from the index
+
+        Params:
+            id_list = point ids to be removed
+
+        Returns: void
+        """
+        for id_ in id_list:
+            flann.remove_point[self.__curindex_type](self.__curindex, id_)
+
+    def set_dataset(self, pts):
+        """
+         set_dataset
+         HACK
+         Updates the underlying dataset to point to new data values.
+         USAGE: used with add_points when the external dataset cannot be resized.
+
+           Params:
+            dataset = pointer to a data set stored in row major order. Must agree with data already stred
+            rows = number of rows (features) in the dataset
+
+        """
+        raise NotImplementedError('dont use')
+        if pts.dtype.type not in allowed_types:
+            raise FLANNException('Cannot handle type: %s' % pts.dtype)
+        pts = ensure_2d_array(pts, default_flags)
+        rows = pts.shape[0]
+        flann.set_dataset[self.__curindex_type](self.__curindex, pts, rows)
+        self.__curindex_data = pts
+        self.__added_data = []
+
     def save_index(self, filename):
         """
         This saves the index to a disk file.
@@ -205,11 +297,13 @@ class FLANN(object):
                 self.__curindex, pointer(self.__flann_parameters))
             self.__curindex = None
             self.__curindex_data = None
+            self.__added_data = []
             self.__curindex_type = None
 
         self.__curindex = flann.load_index[pts.dtype.type](
             c_char_p(to_bytes(filename)), pts, npts, dim)
         self.__curindex_data = pts
+        self.__added_data = []
         self.__curindex_type = pts.dtype.type
 
     def nn_index(self, qpts, num_neighbors=1, **kwargs):
@@ -231,7 +325,7 @@ class FLANN(object):
 
         qpts = ensure_2d_array(qpts, default_flags)
 
-        npts, dim = self.__curindex_data.shape
+        npts, dim = self.get_indexed_shape()
 
         if qpts.size == dim:
             qpts.reshape(1, dim)
@@ -271,8 +365,8 @@ class FLANN(object):
         if self.__curindex_type != query.dtype.type:
             raise FLANNException('Index and query must have the same type')
 
-        npts, dim = self.__curindex_data.shape
-        assert query.shape[0] == dim, 'data and query must have the same dims'
+        npts, dim = self.get_indexed_shape()
+        assert(query.shape[0] == dim), 'data and query must have the same dims'
 
         result = np.empty(npts, dtype=index_type)
         if self.__curindex_type == np.float64:
@@ -292,7 +386,8 @@ class FLANN(object):
     def delete_index(self, **kwargs):
         """
         Deletes the current index freeing all the momory it uses.
-        The memory used by the dataset that was indexed is not freed.
+        The memory used by the dataset that was indexed is not freed
+        unless there are no other references to those numpy arrays.
         """
 
         self.__flann_parameters.update(kwargs)
@@ -302,6 +397,7 @@ class FLANN(object):
                 self.__curindex, pointer(self.__flann_parameters))
             self.__curindex = None
             self.__curindex_data = None
+            self.__added_data = []
 
     ##########################################################################
     # Clustering functions

--- a/test/test_add_remove.py
+++ b/test/test_add_remove.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import pyflann
+import sys
+import numpy as np
+import unittest
+
+VALID_INT_TYPES = (np.typeDict['int64'],
+                   np.typeDict['int32'],
+                   np.typeDict['uint8'],
+                   np.dtype('int32'),
+                   np.dtype('uint8'),
+                   np.dtype('int64'),)
+
+
+def is_int_type(dtype):
+    if sys.platform == 'win32':
+        return dtype.type in VALID_INT_TYPES
+    else:
+        return dtype in VALID_INT_TYPES
+
+
+def rand_vecs(num, dim, rng=np.random, dtype=np.uint8):
+    if is_int_type(dtype):
+        return (rng.rand(num, dim) * 255).astype(dtype)
+    else:
+        return (rng.rand(num, dim)).astype(dtype)
+
+
+class Test_PyFlann_add_remove(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_add_loop(self):
+        """
+        Test add_points using a loop when the added data goes out of scope.
+        """
+        data_dim = 128
+        num_qpts = 100
+        num_dpts = 1000
+        random_seed = 42
+        rng = np.random.RandomState(0)
+
+        dataset = rand_vecs(num_dpts, data_dim, rng)
+        testset = rand_vecs(num_qpts, data_dim, rng)
+
+        # Build determenistic flann object
+        flann = pyflann.FLANN()
+        params = flann.build_index(dataset, algorithm='kdtree', trees=4, random_seed=random_seed)
+
+        # Add points in a loop where new_pts goes out of scope
+        num_iters = 100
+        for count in range(num_iters):
+            new_pts = rand_vecs(200, data_dim, rng)
+            flann.add_points(new_pts, 2)
+
+        # query to ensure that at least some of the new points are in the results
+        num_extra = 200
+        num_neighbs = num_dpts + num_extra
+        result1, _ = flann.nn_index(testset, num_neighbs, checks=params['checks'])
+        self.assertTrue((result1 > num_dpts).sum() >= num_qpts * num_extra, 'at least some of the returned points should be from the added set')
+
+    def test_add(self):
+        """
+        Test simple case of add_points
+        """
+        data_dim = 128
+        num_dpts = 1000
+        num_qpts = 100
+        num_neighbs = 5
+        random_seed = 42
+        rng = np.random.RandomState(0)
+
+        dataset = rand_vecs(num_dpts, data_dim, rng)
+        testset = rand_vecs(num_qpts, data_dim, rng)
+        # Build determenistic flann object
+        flann = pyflann.FLANN()
+        params = flann.build_index(dataset, algorithm='kdtree', trees=4, random_seed=random_seed)
+
+        # check nearest neighbor search before add, should be all over the place
+        result1, _ = flann.nn_index(testset, num_neighbs, checks=params['checks'])
+
+        # Add points
+        flann.add_points(testset, 2)
+
+        # check nearest neighbor search after add
+        result2, _ = flann.nn_index(testset, num_neighbs, checks=params['checks'])
+
+        #print('Neighbor results should be between %d and %d' % (num_dpts, num_dpts + num_qpts))
+        self.assertTrue(np.all(result2.T[0] >= num_dpts), 'new points should be found first')
+        self.assertTrue((result2.T[1] == result1.T[0]).sum() > result1.shape[0] / 2, 'most old points should be found next')
+
+    def test_remove(self):
+        """
+        Test simple case of remove points
+        """
+        data_dim = 128
+        num_dpts = 1000
+        num_neighbs = 5
+        random_seed = 42
+        rng = np.random.RandomState(0)
+        dataset = rand_vecs(num_dpts, data_dim, rng)
+        rng = np.random.RandomState(0)
+
+        # Build determenistic flann object
+        flann = pyflann.FLANN()
+        params = flann.build_index(dataset, algorithm='kdtree', trees=4, random_seed=random_seed)
+
+        # check nearest neighbor search before add, should be all over the place
+        result1, _ = flann.nn_index(dataset, num_neighbs, checks=params['checks'])
+
+        data_ids = np.arange(0, dataset.shape[0])
+
+        check1 = result1.T[0] == data_ids
+        self.assertTrue(np.all(check1), 'self query should result in consecutive results')
+
+        # Remove half of the data points
+        for id_ in range(0, num_dpts, 2):
+            flann.remove_point(id_)
+
+        result2, _ = flann.nn_index(dataset, num_neighbs, checks=params['checks'])
+
+        check2_odd = result2.T[0][1::2] == data_ids[1::2]
+        check2_even = result2.T[0][0::2] == data_ids[0::2]
+        self.assertTrue(np.all(check2_odd), 'unremoved points should have unchanged neighbors')
+        self.assertTrue(not np.any(check2_even), 'removed points should have different neighbors')
+
+    def test_used_memory(self):
+        """
+        Simple test to make sure the used_memory binding works
+        """
+        data_dim = 128
+        num_dpts = 1000
+        num_qpts = 100
+        num_neighbs = 5
+        random_seed = 42
+        rng = np.random.RandomState(0)
+
+        dataset = rand_vecs(num_dpts, data_dim, rng)
+        testset = rand_vecs(num_qpts, data_dim, rng)
+        # Build determenistic flann object
+        flann = pyflann.FLANN()
+        params = flann.build_index(dataset, algorithm='kdtree', trees=4, random_seed=random_seed)
+
+        # check nearest neighbor search before add, should be all over the place
+        result1, _ = flann.nn_index(testset, num_neighbs, checks=params['checks'])
+
+        prev_index_memory = flann.used_memory()
+        prev_data_memory = flann.used_memory_dataset()
+
+        # Add points
+        flann.add_points(testset, 2)
+
+        # check memory after add points
+        post_index_memory = flann.used_memory()
+        post_data_memory = flann.used_memory_dataset()
+
+        index_memory_diff = post_index_memory - prev_index_memory
+        data_memory_diff = post_data_memory - prev_data_memory
+
+        self.assertTrue(index_memory_diff > 0, 'add points should increase memory usage')
+        self.assertTrue(data_memory_diff > 0, 'add points should increase memory usage')
+
+
+if __name__ == '__main__':
+    """
+    CommandLine:
+        python test/test_add_remove.py
+    """
+    unittest.main()


### PR DESCRIPTION
Added add_points python binding. This binding was adapted from Abraham
Hindle's version. The FLANN python object keeps a reference to added
the ndarrays to prevent segfaults.

Added python bindings for remove_point

Added python bindings for memory_usage

Added unit tests for new python bindings