### PR TITLE
Added error in load_index python bindings

### DIFF
--- a/src/python/pyflann/index.py
+++ b/src/python/pyflann/index.py
@@ -209,6 +209,12 @@ class FLANN(object):
 
         self.__curindex = flann.load_index[pts.dtype.type](
             c_char_p(to_bytes(filename)), pts, npts, dim)
+
+        if self.__curindex is None:
+            raise FLANNException(
+                ('Error loading the FLANN index with filename=%r.'
+                 ' C++ may have thrown more detailed errors') % (filename,))
+
         self.__curindex_data = pts
         self.__curindex_type = pts.dtype.type
 

--- a/test/test_index_save.py
+++ b/test/test_index_save.py
@@ -14,7 +14,7 @@ class Test_PyFLANN_nn(unittest.TestCase):
 
 
 class Test_PyFLANN_nn_index(unittest.TestCase):
-    
+
     def testnn_index_save_kdtree_1(self):
         self.run_nn_index_save_perturbed(64,1000, algorithm="kdtree", trees=1)
 
@@ -30,16 +30,16 @@ class Test_PyFLANN_nn_index(unittest.TestCase):
 
     def testnn_index_save_kmeans_16(self):
         self.run_nn_index_save_perturbed(64,1000, algorithm="kmeans", branching=16, iterations=11)
-    
+
     def testnn_index_save_kmeans_32(self):
         self.run_nn_index_save_perturbed(64,1000, algorithm="kmeans", branching=32, iterations=11)
-    
+
     def testnn_index_save_kmeans_64(self):
         self.run_nn_index_save_perturbed(64,1000, algorithm="kmeans", branching=64, iterations=11)
 
 
     def testnn__save_kdtree_1(self):
-        self.run_nn_index_save_rand(64,10000,1000, algorithm="kdtree", trees=1, checks=128)    
+        self.run_nn_index_save_rand(64,10000,1000, algorithm="kdtree", trees=1, checks=128)
 
     def testnn__save_kdtree_4(self):
         self.run_nn_index_save_rand(64,10000,1000, algorithm="kdtree", trees=4, checks=128)
@@ -55,15 +55,99 @@ class Test_PyFLANN_nn_index(unittest.TestCase):
 
     def testnn__save_kmeans_16(self):
         self.run_nn_index_save_rand(64,10000,1000, algorithm="kmeans", branching=16, iterations=11, checks=40)
-    
+
     def testnn__save_kmeans_32(self):
         self.run_nn_index_save_rand(64,10000,1000, algorithm="kmeans", branching=32, iterations=11, checks=56)
 
+    def testnn__load_nonflann_index(self):
+        N = 100
+        dim = 128
 
+        x = rand(N, dim)
+        # try loading something that is not a flann saved index
+        with open("index.test.corrupted", 'wb') as file_:
+            file_.write('not a flann index')
 
+        nn = FLANN()
+        try:
+            # Make sure this throws an error
+            nn.load_index("index.test.corrupted", x)
+        except FLANNException as ex:
+            did_error = True
+            print(ex)
+        else:
+            did_error = False
+        self.assertTrue(did_error, 'should error')
+
+    def testnn__load_incorrect_dtype(self):
+        N = 100
+        dim = 128
+
+        x = (rand(N, dim) * 255).astype(uint8)
+        y = rand(N, dim).astype(float32)
+
+        nn = FLANN()
+        nn.build_index(x)
+        nn.save_index("index.dat")
+        del nn
+
+        nn = FLANN()
+        try:
+            # Make sure this throws an error
+            nn.load_index("index.dat", y)
+        except FLANNException as ex:
+            did_error = True
+            print(ex)
+        else:
+            did_error = False
+        self.assertTrue(did_error, 'should error')
+
+    def testnn__load_incorrect_numdata(self):
+        N = 100
+        dim = 128
+
+        x = rand(N, dim)
+        y = rand(N * 2, dim)
+
+        nn = FLANN()
+        nn.build_index(x)
+        nn.save_index("index.dat")
+        del nn
+
+        nn = FLANN()
+        try:
+            # Make sure this throws an error
+            nn.load_index("index.dat", y)
+        except FLANNException as ex:
+            did_error = True
+            print(ex)
+        else:
+            did_error = False
+        self.assertTrue(did_error, 'should error')
+
+    # CURRENTLY FAILS
+    #def testnn__load_incorrect_numdims(self):
+    #    N = 100
+    #    dim = 128
+    #    x = rand(N, dim)
+    #    y = rand(N, dim * 2)
+    #    nn = FLANN()
+    #    nn.build_index(x)
+    #    nn.save_index("index.dat")
+    #    del nn
+    #    nn = FLANN()
+    #    try:
+    #        # Make sure this throws an error
+    #        nn.load_index("index.dat", y)
+    #    except FLANNException as ex:
+    #        did_error = True
+    #        print(ex)
+    #    else:
+    #        did_error = False
+    #    self.assertTrue(did_error, 'should error')
 
     def run_nn_index_save_perturbed(self, dim, N, **kwargs):
-        
+
         x = rand(N, dim)
 
         nn = FLANN()
@@ -76,10 +160,11 @@ class Test_PyFLANN_nn_index(unittest.TestCase):
         x_query = x + randn(x.shape[0], x.shape[1])*0.0001/dim
         nnidx, nndist = nn.nn_index(x_query)
         correct = all(nnidx == arange(N, dtype = index_type))
-                
+
         nn.delete_index()
         self.assertTrue(correct)
-    
+
+
     def run_nn_index_save_rand(self, dim, N, Nq, **kwargs):
 
         x = rand(N, dim)


### PR DESCRIPTION
New error handles the case when a file with an old signature is loaded
Added a test case to test the new error.

Previously C++ printed out an error message and the python side failed
silently. New test cases also handles trying to load an invalid index.
Tests the cases of incorrect file types, different data types, and
different data lengths. Different dimensions does not seem to throw
an error in the C++ code, so that test is commented out.