### PR TITLE
fix constructor and deconstructor of the node of the hierarchical_clu…

### DIFF
--- a/src/cpp/flann/algorithms/hierarchical_clustering_index.h
+++ b/src/cpp/flann/algorithms/hierarchical_clustering_index.h
@@ -361,6 +361,10 @@ private:
          */
         std::vector<PointInfo> points;
 
+		Node(){
+			pivot = NULL;
+			pivot_index = SIZE_MAX;
+		}
         /**
          * destructor
          * calling Node destructor explicitly
@@ -369,6 +373,8 @@ private:
         {
         	for(size_t i=0; i<childs.size(); i++){
         		childs[i]->~Node();
+				pivot = NULL;
+				pivot_index = -1;
         	}
         };
 
@@ -380,7 +386,10 @@ private:
     		Index* obj = static_cast<Index*>(ar.getObject());
     		ar & pivot_index;
     		if (Archive::is_loading::value) {
-    			pivot = obj->points_[pivot_index];
+				if (pivot_index != SIZE_MAX)
+					pivot = obj->points_[pivot_index];
+				else
+					pivot = NULL;
     		}
     		size_t childs_size;
     		if (Archive::is_saving::value) {


### PR DESCRIPTION
…stering_index tree.

This bug will cause the serialization of the hierarchical_clustering_index to crash. Because when saving the index, the pivot and pivot_index for the top node of each tree is not initializaed. then when load these top nodes, pivot = obj->points_[pivot_index]; will cause error that index is out of range.