### PR TITLE
Added support for the more flexible setuptools library

### DIFF
--- a/src/python/setup.py.tpl
+++ b/src/python/setup.py.tpl
@@ -1,6 +1,10 @@
 #!/usr/bin/env python2
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    print('setuptools is not installed. Falling back to distutils.core')
+    from distutils.core import setup
 from os.path import exists, abspath, dirname, join
 import os
 import sys


### PR DESCRIPTION
Although setuptools is not in the Python standard library, it greatly extends the functionality of distutils. It is preferred over distutils in projects like numpy and scipy. 