### PR TITLE
Normalize line endings for config.h and setup.py.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 .gitignore      export-ignore
 .gitattributes      export-ignore
+
+src/cpp/flann/config.h eol=lf
+src/python/setup.py eol=lf

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -2,7 +2,11 @@
 
 add_definitions(-D_FLANN_VERSION=${FLANN_VERSION})
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/flann/config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/flann/config.h)
+# Enforce NEWLINE_STYLE to UNIX to prevent Git from finding the file dirty.
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/flann/config.h.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/flann/config.h
+    NEWLINE_STYLE UNIX
+)
 
 file(GLOB_RECURSE C_SOURCES flann.cpp lz4.c lz4hc.c)
 file(GLOB_RECURSE CPP_SOURCES flann_cpp.cpp lz4.c lz4hc.c)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,4 +1,5 @@
-configure_file( setup.py.tpl setup.py )
+# Enforce NEWLINE_STYLE to UNIX to prevent Git from finding the file dirty.
+configure_file( setup.py.tpl setup.py NEWLINE_STYLE UNIX )
 
 install( DIRECTORY pyflann DESTINATION share/flann/python )
 install( FILES ${CMAKE_CURRENT_BINARY_DIR}/setup.py DESTINATION share/flann/python )


### PR DESCRIPTION
Currently, CMake configure_file is used to modify files in the source
directory.  Default CMake behavior is to use the host operating system's
line ending.  This can lead to Git deciding that the working tree is dirty.

Here, we standardize line endings for these files using .gitattributes and
use NEWLINE_STYLE CMake option to match with the chosen line endings.