### PR TITLE
C wrapper fix for C++99

### DIFF
--- a/src/cpp/flann/flann.cpp
+++ b/src/cpp/flann/flann.cpp
@@ -313,29 +313,29 @@ template <typename T>
 int _flann_add_points(flann_index_t index_ptr, T* points, int rows, int columns,
                 float rebuild_threshold) {
     if (flann_distance_type==FLANN_DIST_EUCLIDEAN) {
-        return __flann_add_points<L2<T>>(index_ptr, points, rows, columns, rebuild_threshold);
+        return __flann_add_points<L2<T> >(index_ptr, points, rows, columns, rebuild_threshold);
     }
     else if (flann_distance_type==FLANN_DIST_MANHATTAN) {
-        return __flann_add_points<L1<T>>(index_ptr, points, rows, columns, rebuild_threshold);
+        return __flann_add_points<L1<T> >(index_ptr, points, rows, columns, rebuild_threshold);
     }
     else if (flann_distance_type==FLANN_DIST_MINKOWSKI) {
-        return __flann_add_points<MinkowskiDistance<T>>(index_ptr, points, rows, columns, rebuild_threshold);
+        return __flann_add_points<MinkowskiDistance<T> >(index_ptr, points, rows, columns, rebuild_threshold);
     }
     else if (flann_distance_type==FLANN_DIST_HIST_INTERSECT) {
-        return __flann_add_points<HistIntersectionDistance<T>>(index_ptr, points, rows, columns, rebuild_threshold);
+        return __flann_add_points<HistIntersectionDistance<T> >(index_ptr, points, rows, columns, rebuild_threshold);
     }
     else if (flann_distance_type==FLANN_DIST_HELLINGER) {
-        return __flann_add_points<HellingerDistance<T>>(index_ptr, points, rows, columns, rebuild_threshold);
+        return __flann_add_points<HellingerDistance<T> >(index_ptr, points, rows, columns, rebuild_threshold);
     }
     else if (flann_distance_type==FLANN_DIST_CHI_SQUARE) {
-        return __flann_add_points<ChiSquareDistance<T>>(index_ptr, points, rows, columns, rebuild_threshold);
+        return __flann_add_points<ChiSquareDistance<T> >(index_ptr, points, rows, columns, rebuild_threshold);
     }
     else if (flann_distance_type==FLANN_DIST_KULLBACK_LEIBLER) {
-        return __flann_add_points<KL_Divergence<T>>(index_ptr, points, rows, columns, rebuild_threshold);
+        return __flann_add_points<KL_Divergence<T> >(index_ptr, points, rows, columns, rebuild_threshold);
     }
     else {
         Logger::error( "Distance type unsupported in the C bindings, use the C++ bindings instead\n");
-        return NULL;
+        return 0;
     }
 }
 
@@ -366,7 +366,6 @@ int flann_add_points_int(flann_index_t index_ptr, int* points, int rows, int col
 
 template <typename Distance>
 int __flann_remove_point(flann_index_t index_ptr, unsigned int point_id_uint) {
-    typedef typename Distance::ElementType ElementType;
     size_t point_id(point_id_uint);
     try {
         if (index_ptr==NULL) {
@@ -386,29 +385,29 @@ int __flann_remove_point(flann_index_t index_ptr, unsigned int point_id_uint) {
 template <typename T>
 int _flann_remove_point(flann_index_t index_ptr, unsigned int point_id) {
     if (flann_distance_type==FLANN_DIST_EUCLIDEAN) {
-        return __flann_remove_point<L2<T>>(index_ptr, point_id);
+        return __flann_remove_point<L2<T> >(index_ptr, point_id);
     }
     else if (flann_distance_type==FLANN_DIST_MANHATTAN) {
-        return __flann_remove_point<L1<T>>(index_ptr, point_id);
+        return __flann_remove_point<L1<T> >(index_ptr, point_id);
     }
     else if (flann_distance_type==FLANN_DIST_MINKOWSKI) {
-        return __flann_remove_point<MinkowskiDistance<T>>(index_ptr, point_id);
+        return __flann_remove_point<MinkowskiDistance<T> >(index_ptr, point_id);
     }
     else if (flann_distance_type==FLANN_DIST_HIST_INTERSECT) {
-        return __flann_remove_point<HistIntersectionDistance<T>>(index_ptr, point_id);
+        return __flann_remove_point<HistIntersectionDistance<T> >(index_ptr, point_id);
     }
     else if (flann_distance_type==FLANN_DIST_HELLINGER) {
-        return __flann_remove_point<HellingerDistance<T>>(index_ptr, point_id);
+        return __flann_remove_point<HellingerDistance<T> >(index_ptr, point_id);
     }
     else if (flann_distance_type==FLANN_DIST_CHI_SQUARE) {
-        return __flann_remove_point<ChiSquareDistance<T>>(index_ptr, point_id);
+        return __flann_remove_point<ChiSquareDistance<T> >(index_ptr, point_id);
     }
     else if (flann_distance_type==FLANN_DIST_KULLBACK_LEIBLER) {
-        return __flann_remove_point<KL_Divergence<T>>(index_ptr, point_id);
+        return __flann_remove_point<KL_Divergence<T> >(index_ptr, point_id);
     }
     else {
         Logger::error( "Distance type unsupported in the C bindings, use the C++ bindings instead\n");
-        return NULL;
+        return 0;
     }
 }
 
@@ -440,7 +439,6 @@ int flann_remove_point_int(flann_index_t index_ptr, unsigned int point_id)
 template <typename Distance>
 typename Distance::ElementType* __flann_get_point(flann_index_t index_ptr,
                                          unsigned int point_id_uint) {
-    typedef typename Distance::ElementType ElementType;
     size_t point_id(point_id_uint);
     try {
         if (index_ptr==NULL) {
@@ -458,25 +456,25 @@ typename Distance::ElementType* __flann_get_point(flann_index_t index_ptr,
 template <typename T>
 T* _flann_get_point(flann_index_t index_ptr, unsigned int point_id) {
     if (flann_distance_type==FLANN_DIST_EUCLIDEAN) {
-        return __flann_get_point<L2<T>>(index_ptr, point_id);
+        return __flann_get_point<L2<T> >(index_ptr, point_id);
     }
     else if (flann_distance_type==FLANN_DIST_MANHATTAN) {
-        return __flann_get_point<L1<T>>(index_ptr, point_id);
+        return __flann_get_point<L1<T> >(index_ptr, point_id);
     }
     else if (flann_distance_type==FLANN_DIST_MINKOWSKI) {
-        return __flann_get_point<MinkowskiDistance<T>>(index_ptr, point_id);
+        return __flann_get_point<MinkowskiDistance<T> >(index_ptr, point_id);
     }
     else if (flann_distance_type==FLANN_DIST_HIST_INTERSECT) {
-        return __flann_get_point<HistIntersectionDistance<T>>(index_ptr, point_id);
+        return __flann_get_point<HistIntersectionDistance<T> >(index_ptr, point_id);
     }
     else if (flann_distance_type==FLANN_DIST_HELLINGER) {
-        return __flann_get_point<HellingerDistance<T>>(index_ptr, point_id);
+        return __flann_get_point<HellingerDistance<T> >(index_ptr, point_id);
     }
     else if (flann_distance_type==FLANN_DIST_CHI_SQUARE) {
-        return __flann_get_point<ChiSquareDistance<T>>(index_ptr, point_id);
+        return __flann_get_point<ChiSquareDistance<T> >(index_ptr, point_id);
     }
     else if (flann_distance_type==FLANN_DIST_KULLBACK_LEIBLER) {
-        return __flann_get_point<KL_Divergence<T>>(index_ptr, point_id);
+        return __flann_get_point<KL_Divergence<T> >(index_ptr, point_id);
     }
     else {
         Logger::error( "Distance type unsupported in the C bindings, use the C++ bindings instead\n");
@@ -511,7 +509,6 @@ int* flann_get_point_int(flann_index_t index_ptr, unsigned int point_id)
 
 template <typename Distance>
 unsigned int __flann_veclen(flann_index_t index_ptr) {
-    typedef typename Distance::ElementType ElementType;
     try {
         if (index_ptr==NULL) {
             throw FLANNException("Invalid index");
@@ -528,29 +525,29 @@ unsigned int __flann_veclen(flann_index_t index_ptr) {
 template <typename T>
 unsigned int _flann_veclen(flann_index_t index_ptr) {
     if (flann_distance_type==FLANN_DIST_EUCLIDEAN) {
-        return __flann_veclen<L2<T>>(index_ptr);
+        return __flann_veclen<L2<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_MANHATTAN) {
-        return __flann_veclen<L1<T>>(index_ptr);
+        return __flann_veclen<L1<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_MINKOWSKI) {
-        return __flann_veclen<MinkowskiDistance<T>>(index_ptr);
+        return __flann_veclen<MinkowskiDistance<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_HIST_INTERSECT) {
-        return __flann_veclen<HistIntersectionDistance<T>>(index_ptr);
+        return __flann_veclen<HistIntersectionDistance<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_HELLINGER) {
-        return __flann_veclen<HellingerDistance<T>>(index_ptr);
+        return __flann_veclen<HellingerDistance<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_CHI_SQUARE) {
-        return __flann_veclen<ChiSquareDistance<T>>(index_ptr);
+        return __flann_veclen<ChiSquareDistance<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_KULLBACK_LEIBLER) {
-        return __flann_veclen<KL_Divergence<T>>(index_ptr);
+        return __flann_veclen<KL_Divergence<T> >(index_ptr);
     }
     else {
         Logger::error( "Distance type unsupported in the C bindings, use the C++ bindings instead\n");
-        return NULL;
+        return 0;
     }
 }
 
@@ -581,7 +578,6 @@ unsigned int flann_veclen_int(flann_index_t index_ptr)
 
 template <typename Distance>
 unsigned int __flann_size(flann_index_t index_ptr) {
-    typedef typename Distance::ElementType ElementType;
     try {
         if (index_ptr==NULL) {
             throw FLANNException("Invalid index");
@@ -598,29 +594,29 @@ unsigned int __flann_size(flann_index_t index_ptr) {
 template <typename T>
 unsigned int _flann_size(flann_index_t index_ptr) {
     if (flann_distance_type==FLANN_DIST_EUCLIDEAN) {
-        return __flann_size<L2<T>>(index_ptr);
+        return __flann_size<L2<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_MANHATTAN) {
-        return __flann_size<L1<T>>(index_ptr);
+        return __flann_size<L1<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_MINKOWSKI) {
-        return __flann_size<MinkowskiDistance<T>>(index_ptr);
+        return __flann_size<MinkowskiDistance<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_HIST_INTERSECT) {
-        return __flann_size<HistIntersectionDistance<T>>(index_ptr);
+        return __flann_size<HistIntersectionDistance<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_HELLINGER) {
-        return __flann_size<HellingerDistance<T>>(index_ptr);
+        return __flann_size<HellingerDistance<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_CHI_SQUARE) {
-        return __flann_size<ChiSquareDistance<T>>(index_ptr);
+        return __flann_size<ChiSquareDistance<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_KULLBACK_LEIBLER) {
-        return __flann_size<KL_Divergence<T>>(index_ptr);
+        return __flann_size<KL_Divergence<T> >(index_ptr);
     }
     else {
         Logger::error( "Distance type unsupported in the C bindings, use the C++ bindings instead\n");
-        return NULL;
+        return 0;
     }
 }
 
@@ -651,7 +647,6 @@ unsigned int flann_size_int(flann_index_t index_ptr)
 
 template <typename Distance>
 int __flann_used_memory(flann_index_t index_ptr) {
-    typedef typename Distance::ElementType ElementType;
     try {
         if (index_ptr==NULL) {
             throw FLANNException("Invalid index");
@@ -668,29 +663,29 @@ int __flann_used_memory(flann_index_t index_ptr) {
 template <typename T>
 int _flann_used_memory(flann_index_t index_ptr) {
     if (flann_distance_type==FLANN_DIST_EUCLIDEAN) {
-        return __flann_used_memory<L2<T>>(index_ptr);
+        return __flann_used_memory<L2<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_MANHATTAN) {
-        return __flann_used_memory<L1<T>>(index_ptr);
+        return __flann_used_memory<L1<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_MINKOWSKI) {
-        return __flann_used_memory<MinkowskiDistance<T>>(index_ptr);
+        return __flann_used_memory<MinkowskiDistance<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_HIST_INTERSECT) {
-        return __flann_used_memory<HistIntersectionDistance<T>>(index_ptr);
+        return __flann_used_memory<HistIntersectionDistance<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_HELLINGER) {
-        return __flann_used_memory<HellingerDistance<T>>(index_ptr);
+        return __flann_used_memory<HellingerDistance<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_CHI_SQUARE) {
-        return __flann_used_memory<ChiSquareDistance<T>>(index_ptr);
+        return __flann_used_memory<ChiSquareDistance<T> >(index_ptr);
     }
     else if (flann_distance_type==FLANN_DIST_KULLBACK_LEIBLER) {
-        return __flann_used_memory<KL_Divergence<T>>(index_ptr);
+        return __flann_used_memory<KL_Divergence<T> >(index_ptr);
     }
     else {
         Logger::error( "Distance type unsupported in the C bindings, use the C++ bindings instead\n");
-        return NULL;
+        return 0;
     }
 }
 


### PR DESCRIPTION
C wrappers pushed in https://github.com/dm-jrae/flann/commit/0aa107c2774ca1b231e72cdf1631fa5b4236a577 were not compatible with earlier versions of C++. Fixes any lingering build issues.