### PR TITLE
Made random number generation deterministic and thread safe.

### DIFF
--- a/src/cpp/flann/algorithms/kdtree_index.h
+++ b/src/cpp/flann/algorithms/kdtree_index.h
@@ -265,7 +265,7 @@ protected:
         /* Construct the randomized trees. */
         for (int i = 0; i < trees_; i++) {
             /* Randomize the order of vectors to allow for unbiased sampling. */
-            std::random_shuffle(ind.begin(), ind.end());
+            rand_shuffle(ind.begin(), ind.end());
             tree_roots_[i] = divideTree(&ind[0], int(size_) );
         }
         delete[] mean_;

--- a/src/cpp/flann/util/lsh_table.h
+++ b/src/cpp/flann/util/lsh_table.h
@@ -50,6 +50,7 @@
 
 #include "flann/util/dynamic_bitset.h"
 #include "flann/util/matrix.h"
+#include "flann/util/random.h"
 
 namespace flann
 {
@@ -364,7 +365,7 @@ inline LshTable<unsigned char>::LshTable(unsigned int feature_size, unsigned int
     // A bit brutal but fast to code
     std::vector<size_t> indices(feature_size * CHAR_BIT);
     for (size_t i = 0; i < feature_size * CHAR_BIT; ++i) indices[i] = i;
-    std::random_shuffle(indices.begin(), indices.end());
+    rand_shuffle(indices.begin(), indices.end());
 
     // Generate a random set of order of subsignature_size_ bits
     for (unsigned int i = 0; i < key_size_; ++i) {

--- a/src/cpp/flann/util/random.h
+++ b/src/cpp/flann/util/random.h
@@ -108,6 +108,17 @@ inline int rand_int(int high = RAND_MAX, int low = 0)
 }
 
 /**
+ * Reorders the elements in the given range [first, last) such that all
+ * permutations of those elements are equally probable.
+ */
+template<typename RandomIt>
+inline void rand_shuffle(RandomIt first, RandomIt last)
+{
+    std::lock_guard<std::mutex> guard(GetRandomNumberGeneratorMutex());
+    std::shuffle(first, last, GetRandomNumberGenerator());
+}
+
+/**
  * Random number generator that returns a distinct number from
  * the [0,n) interval each time.
  */
@@ -140,8 +151,7 @@ public:
         for (int i = 0; i < size_; ++i) vals_[i] = i;
 
         // shuffle the elements in the array
-        std::lock_guard<std::mutex> guard(GetRandomNumberGeneratorMutex());
-        std::shuffle(vals_.begin(), vals_.end(), GetRandomNumberGenerator());
+        rand_shuffle(vals_.begin(), vals_.end());
 
         counter_ = 0;
     }


### PR DESCRIPTION
* Replaced std::rand() calls with a C++11 RNG to make them deterministic. (std::rand() uses global state which is shared by all libraries.)
* Replaced std::random_shuffle() with std::shuffle() since the former calls std::rand() internally.
* Made RNG calls thread safe.  (Fixes Git Issue #116.)

Please verify that this code is correct and passes all tests before accepting this pull request.
