### PR TITLE
fixed issue#209

### DIFF
--- a/src/cpp/flann/util/serialization.h
+++ b/src/cpp/flann/util/serialization.h
@@ -110,7 +110,7 @@ BASIC_TYPE_SERIALIZER(bool);
 // unsigned __int64 ~= unsigned long long
 // Will throw error on VS2013
 #if _MSC_VER != 1800
-BASIC_TYPE_SERIALIZER(unsigned __int64);
+//BASIC_TYPE_SERIALIZER(unsigned __int64);
 #endif
 #endif
 


### PR DESCRIPTION
When building via VS2013 or VS2015 , as said by @peter95 on https://github.com/mariusmuja/flann/issues/209, __int 64 was an issue which raised this error. By removing the line 113, I was able to successfully build flann using cmake and VS 2015 x64 on windows 10. Please review. 

However, a minor workaround was required as I also had to manually create a include directory in build folder and copy flann/src/cpp/flann to it before building. Still working on automating this. 

Sorry if its the wrong protocol. I am new at this.