### PR TITLE
Fix deletion in kmeans_index.h

### DIFF
--- a/src/cpp/flann/algorithms/kmeans_index.h
+++ b/src/cpp/flann/algorithms/kmeans_index.h
@@ -525,7 +525,7 @@ private:
 
         node->variance = variance;
         node->radius = radius;
-        delete node->pivot;
+        delete[] node->pivot;
         node->pivot = mean;
     }
 


### PR DESCRIPTION
I'm so sorry, I mispasted the fix in the previous pull request. Both deletions need to be array deletions.