### PR TITLE
add ability to get point ids from addPoints

### DIFF
--- a/src/cpp/flann/algorithms/autotuned_index.h
+++ b/src/cpp/flann/algorithms/autotuned_index.h
@@ -130,7 +130,8 @@ public:
     }
 
     /**
-     *          Method responsible with building the index.
+     * Method responsible with building the index. Note that IDs previously
+     * assigned to points are reset in the autotuned index
      */
     void buildIndex()
     {
@@ -161,10 +162,10 @@ public:
     }
 
 
-    void addPoints(const Matrix<ElementType>& points, float rebuild_threshold = 2)
+    void addPoints(const Matrix<ElementType>& points, std::vector<size_t> *ids, float rebuild_threshold = 2)
     {
         if (bestIndex_) {
-            bestIndex_->addPoints(points, rebuild_threshold);
+            bestIndex_->addPoints(points, ids, rebuild_threshold);
         }
     }
     

--- a/src/cpp/flann/algorithms/composite_index.h
+++ b/src/cpp/flann/algorithms/composite_index.h
@@ -166,10 +166,10 @@ public:
         kdtree_index_->buildIndex();
     }
     
-    void addPoints(const Matrix<ElementType>& points, float rebuild_threshold = 2)
+    void addPoints(const Matrix<ElementType>& points, std::vector<size_t> *ids, float rebuild_threshold = 2)
     {
-        kmeans_index_->addPoints(points, rebuild_threshold);
-        kdtree_index_->addPoints(points, rebuild_threshold);
+        kmeans_index_->addPoints(points, NULL, rebuild_threshold);
+        kdtree_index_->addPoints(points, ids, rebuild_threshold);
     }
 
     void removePoint(size_t index)

--- a/src/cpp/flann/algorithms/hierarchical_clustering_index.h
+++ b/src/cpp/flann/algorithms/hierarchical_clustering_index.h
@@ -206,12 +206,12 @@ public:
     
     using BaseClass::buildIndex;
 
-    void addPoints(const Matrix<ElementType>& points, float rebuild_threshold = 2)
+    void addPoints(const Matrix<ElementType>& points, std::vector<size_t> *ids, float rebuild_threshold = 2)
     {
         assert(points.cols==veclen_);
         size_t old_size = size_;
 
-        extendDataset(points);
+        extendDataset(points, ids);
         
         if (rebuild_threshold>1 && size_at_build_*rebuild_threshold<size_) {
             buildIndex();

--- a/src/cpp/flann/algorithms/kdtree_index.h
+++ b/src/cpp/flann/algorithms/kdtree_index.h
@@ -139,12 +139,12 @@ public:
 
     using BaseClass::buildIndex;
     
-    void addPoints(const Matrix<ElementType>& points, float rebuild_threshold = 2)
+    void addPoints(const Matrix<ElementType>& points, std::vector<size_t> *ids, float rebuild_threshold = 2)
     {
         assert(points.cols==veclen_);
 
         size_t old_size = size_;
-        extendDataset(points);
+        extendDataset(points, ids);
         
         if (rebuild_threshold>1 && size_at_build_*rebuild_threshold<size_) {
             buildIndex();

--- a/src/cpp/flann/algorithms/kdtree_single_index.h
+++ b/src/cpp/flann/algorithms/kdtree_single_index.h
@@ -140,10 +140,10 @@ public:
 
     using BaseClass::buildIndex;
 
-    void addPoints(const Matrix<ElementType>& points, float rebuild_threshold = 2)
+    void addPoints(const Matrix<ElementType>& points, std::vector<size_t> *ids, float rebuild_threshold = 2)
     {
         assert(points.cols==veclen_);
-        extendDataset(points);
+        extendDataset(points, ids);
         buildIndex();
     }
 

--- a/src/cpp/flann/algorithms/kmeans_index.h
+++ b/src/cpp/flann/algorithms/kmeans_index.h
@@ -212,12 +212,12 @@ public:
 
     using BaseClass::buildIndex;
 
-    void addPoints(const Matrix<ElementType>& points, float rebuild_threshold = 2)
+    void addPoints(const Matrix<ElementType>& points, std::vector<size_t> *ids, float rebuild_threshold = 2)
     {
         assert(points.cols==veclen_);
         size_t old_size = size_;
 
-        extendDataset(points);
+        extendDataset(points, ids);
         
         if (rebuild_threshold>1 && size_at_build_*rebuild_threshold<size_) {
             buildIndex();

--- a/src/cpp/flann/algorithms/linear_index.h
+++ b/src/cpp/flann/algorithms/linear_index.h
@@ -85,10 +85,10 @@ public:
     	return new LinearIndex(*this);
     }
 
-    void addPoints(const Matrix<ElementType>& points, float rebuild_threshold = 2)
+    void addPoints(const Matrix<ElementType>& points, std::vector<size_t> *ids, float rebuild_threshold = 2)
     {
         assert(points.cols==veclen_);
-        extendDataset(points);
+        extendDataset(points, ids);
     }
 
     flann_algorithm_t getType() const

--- a/src/cpp/flann/algorithms/lsh_index.h
+++ b/src/cpp/flann/algorithms/lsh_index.h
@@ -143,12 +143,12 @@ public:
     
     using BaseClass::buildIndex;
 
-    void addPoints(const Matrix<ElementType>& points, float rebuild_threshold = 2)
+    void addPoints(const Matrix<ElementType>& points, std::vector<size_t> *ids, float rebuild_threshold = 2)
     {
         assert(points.cols==veclen_);
         size_t old_size = size_;
 
-        extendDataset(points);
+        extendDataset(points, ids);
         
         if (rebuild_threshold>1 && size_at_build_*rebuild_threshold<size_) {
             buildIndex();

--- a/src/cpp/flann/algorithms/nn_index.h
+++ b/src/cpp/flann/algorithms/nn_index.h
@@ -144,12 +144,14 @@ public:
         this->buildIndex();
     }
 
-	/**
-	 * @brief Incrementally add points to the index.
-	 * @param points Matrix with points to be added
-	 * @param rebuild_threshold
-	 */
-    virtual void addPoints(const Matrix<ElementType>& points, float rebuild_threshold = 2)
+    /**
+     * @brief Incrementally add points to the index, returning the resulting
+     * point IDs
+     * @param points Matrix with points to be added
+     * @param ids output vector of point IDs, ignored if NULL
+     * @param rebuild_threshold
+     */
+    virtual void addPoints(const Matrix<ElementType>& points, std::vector<size_t> *ids, float rebuild_threshold = 2)
     {
         throw FLANNException("Functionality not supported by this index");
     }
@@ -760,12 +762,17 @@ protected:
     	}
     }
 
-    void extendDataset(const Matrix<ElementType>& new_points)
+    void extendDataset(const Matrix<ElementType>& new_points, std::vector<size_t> *ids)
     {
     	size_t new_size = size_ + new_points.rows;
+    	size_t start_id;
     	if (removed_) {
     		removed_points_.resize(new_size);
     		ids_.resize(new_size);
+    		start_id = last_id_;
+    	}
+    	else {
+    		start_id = size_;
     	}
     	points_.resize(new_size);
     	for (size_t i=size_;i<new_size;++i) {
@@ -775,6 +782,12 @@ protected:
     			removed_points_.reset(i);
     		}
     	}
+    	if (ids != NULL) {
+    		ids->resize(new_points.rows);
+    		for (size_t i = 0; i < new_points.rows; i++) {
+    			(*ids)[i] = start_id++;
+    		}
+   		}
     	size_ = new_size;
     }
 

--- a/src/cpp/flann/flann.h
+++ b/src/cpp/flann/flann.h
@@ -32,6 +32,7 @@
 #define FLANN_H_
 
 #include "defines.h"
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -163,6 +164,7 @@ FLANN_EXPORT flann_index_t flann_build_index_int(int* dataset,
     points = pointer to array of points
     rows = number of points to add
     columns = feature dimensionality
+    ids = output ids
     rebuild_threshold = reallocs index when it grows by factor of
       `rebuild_threshold`. A smaller value results is more space efficient
       but less computationally efficient. Must be greater than 1.
@@ -188,6 +190,36 @@ FLANN_EXPORT int flann_add_points_byte(flann_index_t index_ptr,
 FLANN_EXPORT int flann_add_points_int(flann_index_t index_ptr, int* points,
                                       int rows, int columns,
                                       float rebuild_threshold);
+
+FLANN_EXPORT int flann_add_points_get_ids(
+        flann_index_t index_ptr,
+        float* points, int rows, int columns,
+        size_t* ids,
+        float rebuild_threshold);
+
+FLANN_EXPORT int flann_add_points_float_get_ids(
+        flann_index_t index_ptr,
+        float* points, int rows, int columns,
+        size_t* ids,
+        float rebuild_threshold);
+
+FLANN_EXPORT int flann_add_points_double_get_ids(
+        flann_index_t index_ptr,
+        double* points, int rows, int columns,
+        size_t* ids,
+        float rebuild_threshold);
+
+FLANN_EXPORT int flann_add_points_byte_get_ids(
+        flann_index_t index_ptr,
+        unsigned char* points, int rows, int columns,
+        size_t* ids,
+        float rebuild_threshold);
+
+FLANN_EXPORT int flann_add_points_int_get_ids(
+        flann_index_t index_ptr,
+        int* points, int rows, int columns,
+        size_t* ids,
+        float rebuild_threshold);
 
 /**
  * Removes a point from a pre-built index.

--- a/src/cpp/flann/flann.hpp
+++ b/src/cpp/flann/flann.hpp
@@ -148,7 +148,12 @@ public:
 
     void addPoints(const Matrix<ElementType>& points, float rebuild_threshold = 2)
     {
-        nnIndex_->addPoints(points, rebuild_threshold);
+        nnIndex_->addPoints(points, NULL, rebuild_threshold);
+    }
+
+    void addPoints(const Matrix<ElementType>& points, std::vector<size_t> &ids, float rebuild_threshold = 2)
+    {
+        nnIndex_->addPoints(points, &ids, rebuild_threshold);
     }
 
     /**

--- a/test/flann_tests.h
+++ b/test/flann_tests.h
@@ -226,10 +226,14 @@ protected:
 		index.buildIndex();
 		EXPECT_EQ(index.size(), data1.rows);
 
-		index.addPoints(data2);
+		std::vector<size_t> ids;
+		index.addPoints(data2, ids);
 		printf("done (%g seconds)\n", stop_timer());
 
 		EXPECT_EQ(index.size(), data.rows);
+		for (size_t i = 0; i < size2; i++) {
+			EXPECT_EQ(ids[i], i+size1);
+		}
 
 		start_timer("Searching KNN...");
 		index.knnSearch(query, indices, dists, knn, search_params);
@@ -298,10 +302,14 @@ protected:
 		index.buildIndex();
 		EXPECT_EQ(index.size(), data1.rows);
 
-		index.addPoints(data2);
+		std::vector<size_t> ids;
+		index.addPoints(data2, ids);
 		printf("done (%g seconds)\n", stop_timer());
 
 		EXPECT_EQ(index.size(), data.rows);
+		for (size_t i = 0; i < size2; i++) {
+			EXPECT_EQ(ids[i], i+size1);
+		}
 
 		start_timer("Searching KNN...");
 		index.knnSearch(query, indices, dists, knn, search_params);


### PR DESCRIPTION
This patch rounds out support for obtaining IDs assigned to points by flann indexes (particularly NNIndex and subclasses) by providing the ability to copy assigned IDs out on calls to Index::addPoints.

An addPoints overload was added to the Index class, and the NNIndex and subclass addPoints functions were modified to take an output pointer. NNIndex::extendDataset sets the output. The overloads were added to the C API, but not the matlab or python APIs - addPoints equivalents aren't unavailable there.

Finally, the addPoints tests were modified to sanity check the ids.