### PR TITLE
Fix HDF5 include directories on recent CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,15 @@ find_hdf5()
 if (NOT HDF5_FOUND)
 	message(WARNING "hdf5 library not found, some tests will not be run")
 else()
-    include_directories(${HDF5_INCLUDE_DIR})
+    # More recent FindHDF5.cmake scripts give output as HDF5_INCLUDE_DIRS and
+    # call HDF5_INCLUDE_DIR deprecated.  But we must check both because early
+    # CMake 2.8 versions provide a FindHDF5.cmake that only give
+    # HDF5_INCLUDE_DIR.
+    if ("${HDF5_INCLUDE_DIR}" STREQUAL "")
+      include_directories(${HDF5_INCLUDE_DIRS})
+    else ()
+      include_directories(${HDF5_INCLUDE_DIR})
+    endif ()
 endif()
 
 if (USE_MPI OR HDF5_IS_PARALLEL)


### PR DESCRIPTION
FindHDF5.cmake doesn't return anything in `HDF5_INCLUDE_DIR` anymore and instead it returns include paths in `HDF5_INCLUDE_DIRS`.  This patch handles both cases.  Notes:

 * The project requires a minimum of CMake 2.6 but FindHDF5.cmake is not available until at least CMake 2.8.0.  You may want to update the minimum required version.

 * There is some workaround for FindHDF5 bugs in `flann_utils.cmake`, which seems to work with `HDF5_INCLUDE_DIRS`, but that variable is not available on FindHDF5.cmake that ships with CMake 2.8.0 (that variable is available as of CMake 2.8.12 or earlier---I did not find the exact point).  So it's possible that the change should not check for `HDF5_INCLUDE_DIR` but should just use `HDF5_INCLUDE_DIRS` directly.