### PR TITLE
setting braces to remove gcc 7.4 warning

### DIFF
--- a/src/cpp/flann/util/any.h
+++ b/src/cpp/flann/util/any.h
@@ -78,7 +78,10 @@ struct big_any_policy : typed_base_any_policy<T>
 {
     virtual void static_delete(void** x)
     {
-        if (* x) delete (* reinterpret_cast<T**>(x)); *x = NULL;
+        if (* x){
+            delete (* reinterpret_cast<T**>(x));
+        }
+        *x = NULL;
     }
     virtual void copy_from_value(void const* src, void** dest)
     {


### PR DESCRIPTION
hope this is helpful. 
Note `make test` fails with https://github.com/mariusmuja/flann/commit/27f9d9333f970b4bccaa95fa06f5a8344e931dc1
as of 
```
[ 84%] Runnint gtest test(s) flann_lsh_test
[==========] Running 8 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 8 tests from LshIndex_Brief100K
[ RUN      ] LshIndex_Brief100K.TestSearch
Reading test data...done
Searching KNN for ground truth...done (1.04125 seconds)
Building LSH index... done (0.386063 seconds)
Searching KNN...done (0.647906 seconds)
/home/steinbac/software/flann/repo/test/flann_tests.h:163: Failure
Expected: (precision) >= (expected_precision), actual: 0.694 vs 0.9
Precision: 0.694
[  FAILED  ] LshIndex_Brief100K.TestSearch (2249 ms)
[ RUN      ] LshIndex_Brief100K.TestSearch2
```
with or without this patch anyhow. 

Quick review: From an isolated point of view, the code I patched confuses the C++ developer in me:

```
template<typename T>
struct big_any_policy : typed_base_any_policy<T>
{
    virtual void static_delete(void** x)
    {
        if (* x){
            delete (* reinterpret_cast<T**>(x));
        }
        *x = NULL;
    }
    virtual void copy_from_value(void const* src, void** dest)
    {
        *dest = new T(*reinterpret_cast<T const*>(src));
    }
```
1. the type system is exploited to set `typed_base_any_policy<T>`
2. the code ignores type information through casts to `void` as in `void static_delete(void** x)`
3. the code then restores type information `delete (* reinterpret_cast<T**>(x));` where any mismatch can not and/or is not detected!