### PR TITLE
fixed wrong reference by name to parameter

### DIFF
--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -450,7 +450,7 @@ Index(const Matrix<ElementType>& points, const IndexParams& params,
         Distance distance = Distance() );
 \end{Verbatim}
 \begin{description}
-\item[features] Matrix containing the features(points) that should be indexed, stored in a row-major order (one point 
+\item[points] Matrix containing the features(points) that should be indexed, stored in a row-major order (one point 
 on each row of the matrix). The size of the matrix is $num\_features \times dimensionality$.
 
 \item[params] Structure containing the index parameters. The type of index that will be constructed depends on the type 


### PR DESCRIPTION
in the same section on page 8, the `distance` parameter is not documented.