### PR TITLE
Minor fix to add/remove-point in python wrapper

### DIFF
--- a/src/python/pyflann/flann_ctypes.py
+++ b/src/python/pyflann/flann_ctypes.py
@@ -256,6 +256,15 @@ flannlib.flann_load_index_%(C)s.argtypes = [
 flann.load_index[%(numpy)s] = flannlib.flann_load_index_%(C)s
 """)
 
+flann.used_memory = {}
+define_functions(r"""
+flannlib.flann_used_memory_%(C)s.restype = c_int
+flannlib.flann_used_memory_%(C)s.argtypes = [
+        FLANN_INDEX, # index_id
+]
+flann.used_memory[%(numpy)s] = flannlib.flann_used_memory_%(C)s
+""")
+
 flann.add_points = {}
 define_functions(r"""
 flannlib.flann_add_points_%(C)s.restype = None

--- a/src/python/pyflann/index.py
+++ b/src/python/pyflann/index.py
@@ -212,6 +212,13 @@ class FLANN(object):
         self.__curindex_data = pts
         self.__curindex_type = pts.dtype.type
         
+        
+    def used_memory(self):
+        """
+        Returns the number of bytes consumed by the index.
+        """
+        return flann.used_memory[self.__curindex_type](self.__curindex)
+        
     def add_points(self, pts, rebuild_threshold=2.0):
         """
         Adds points to pre-built index.

--- a/src/python/pyflann/index.py
+++ b/src/python/pyflann/index.py
@@ -228,12 +228,14 @@ class FLANN(object):
         pts = ensure_2d_array(pts,default_flags) 
         npts, dim = pts.shape
         flann.add_points[self.__curindex_type](self.__curindex, pts, npts, dim, rebuild_threshold)
+        self.__curindex_data = np.row_stack((self.__curindex_data,pts))
         
     def remove_point(self, idx):
         """
         Removes a point from a pre-built index.         
         """
         flann.remove_point[self.__curindex_type](self.__curindex, idx)
+        self.__curindex_data = np.delete(self.__curindex_data,idx,axis=0)
 
     def nn_index(self, qpts, num_neighbors=1, **kwargs):
         """


### PR DESCRIPTION
I forgot to update the internal representation of the points in index.py. This is fixed here.

Speaking of this, is there a good reason to store all points in memory as is currently done in the python-wrapper? As far as I can see, the only way these are ever used is for accessing their shape. Simple bookkeeping of row-count and dimensionality would cost close to nothing and release some memory - especially for large indexes.