### PR TITLE
fix compilation via gcc and cuda 9.1

### DIFF
--- a/src/cpp/flann/algorithms/kdtree_cuda_3d_index.cu
+++ b/src/cpp/flann/algorithms/kdtree_cuda_3d_index.cu
@@ -32,6 +32,7 @@
 #include <flann/util/cuda/result_set.h>
 // #define THRUST_DEBUG 1
 #include <cuda.h>
+#include <thrust/gather.h>
 #include <thrust/copy.h>
 #include <thrust/device_vector.h>
 #include <vector_types.h>


### PR DESCRIPTION
add missing #include <thrust/gather> to kdtree_cuda_3d_index.cu
fix error:
/dependencies_sources/flann/src/cpp/flann/algorithms/kdtree_cuda_3d_index.cu(764): error: namespace "thrust" has no member "gather"
