### PR TITLE
fixing unreachable code in lsh_table.h

### DIFF
--- a/src/cpp/flann/util/lsh_table.h
+++ b/src/cpp/flann/util/lsh_table.h
@@ -234,8 +234,7 @@ public:
     size_t getKey(const ElementType* /*feature*/) const
     {
         std::cerr << "LSH is not implemented for that type" << std::endl;
-        throw;
-        return 1;
+        return -1;
     }
 
     /** Get statistics about the table


### PR DESCRIPTION
After a throw, return is not actually reachable. Code should immediately return after throw. So, it creates an unreachable code warning. With a -wx flag these warnings are considered as errors which is important to fix I believe.  To keep the code consistent with the rest of the code removing the throw seemed more appropriate and returning a -1 seems logical. 

Thanks,
Ahmad  