### PR TITLE
Resolves unordered map conflict with opencv 

### DIFF
--- a/src/cpp/flann/util/lsh_table.h
+++ b/src/cpp/flann/util/lsh_table.h
@@ -39,8 +39,8 @@
 #include <iostream>
 #include <iomanip>
 #include <limits.h>
-// TODO as soon as we use C++0x, use the code in USE_UNORDERED_MAP
-#if USE_UNORDERED_MAP
+// TODO as soon as we use C++0x, use the code in FLANN_USE_UNORDERED_MAP
+#if FLANN_USE_UNORDERED_MAP
 #include <unordered_map>
 #else
 #include <map>
@@ -127,7 +127,7 @@ class LshTable
 public:
     /** A container of all the feature indices. Optimized for space
      */
-#if USE_UNORDERED_MAP
+#if FLANN_USE_UNORDERED_MAP
     typedef std::unordered_map<BucketKey, Bucket> BucketsSpace;
 #else
     typedef std::map<BucketKey, Bucket> BucketsSpace;
@@ -187,7 +187,7 @@ public:
      */
     void add(const std::vector< std::pair<size_t, ElementType*> >& features)
     {
-#if USE_UNORDERED_MAP
+#if FLANN_USE_UNORDERED_MAP
         buckets_space_.rehash((buckets_space_.size() + features.size()) * 1.2);
 #endif
         // Add the features to the table


### PR DESCRIPTION
This PR resolves the issue #214 
It causes issues when using opencv and pcl together if we use the kdTree from pcl which uses flann. This is a very frequent case where keeping in mind the include order as [this](https://github.com/jsk-ros-pkg/jsk_recognition/pull/2023) does not seem right. And USE_UNORDERED_MAP macro is a very generic name, if guarded with a FLANN_ prefix it makes sure that no collision happens with other libraries.