### PR TITLE
Fix if indentation warning

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -30,7 +30,7 @@ if (BUILD_CUDA_LIB)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_COMPILER_IS_GNUCC)
-    add_library(flann_cpp SHARED "")
+    add_library(flann_cpp SHARED ${CPP_SOURCES})
     set_target_properties(flann_cpp PROPERTIES LINKER_LANGUAGE CXX)
     target_link_libraries(flann_cpp -Wl,-whole-archive flann_cpp_s -Wl,-no-whole-archive)
 

--- a/src/cpp/flann/util/any.h
+++ b/src/cpp/flann/util/any.h
@@ -78,7 +78,8 @@ struct big_any_policy : typed_base_any_policy<T>
 {
     virtual void static_delete(void** x)
     {
-        if (* x) delete (* reinterpret_cast<T**>(x)); *x = NULL;
+        if (* x) delete (* reinterpret_cast<T**>(x));
+        *x = NULL;
     }
     virtual void copy_from_value(void const* src, void** dest)
     {


### PR DESCRIPTION
```cpp
    || src/cpp/flann/util/any.h: In member function ‘virtual void flann::anyimpl::big_any_policy<T>::static_delete(void**)’:
    src/cpp/flann/util/any.h|81 col 9| warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
    ||    81 |         if (* x) delete (* reinterpret_cast<T**>(x)); *x = NULL;
    ||       |         ^~
    src/cpp/flann/util/any.h|81 col 55| note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
    ||    81 |         if (* x) delete (* reinterpret_cast<T**>(x)); *x = NULL;
```
