### PR TITLE
Resolve warning due to -Wmisleading-indentation

### DIFF
--- a/src/cpp/flann/util/any.h
+++ b/src/cpp/flann/util/any.h
@@ -78,7 +78,8 @@ struct big_any_policy : typed_base_any_policy<T>
 {
     virtual void static_delete(void** x)
     {
-        if (* x) delete (* reinterpret_cast<T**>(x)); *x = NULL;
+        if (* x) delete (* reinterpret_cast<T**>(x));
+	*x = NULL;
     }
     virtual void copy_from_value(void const* src, void** dest)
     {


### PR DESCRIPTION
The misleading indented statement can be executed regardless of the if condition