### PR TITLE
add cmake_cxx_flags -std=c++11 in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(${PROJECT_SOURCE_DIR}/cmake/flann_utils.cmake)
 set(FLANN_VERSION 1.9.1)
 DISSECT_VERSION()
 GET_OS_INFO()
-
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 # detect if using the Clang compiler
 if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15307921/68065261-19208d80-fcfd-11e9-995a-a6347b2b59ad.png)

this flag is needed when I compile the project.
