### PR TITLE
Fix stack-use-after-scope in any.h detected by asan

### DIFF
--- a/src/cpp/flann/util/any.h
+++ b/src/cpp/flann/util/any.h
@@ -233,7 +233,7 @@ public:
 
     /// Cast operator. You can only cast to the original type.
     template<typename T>
-    T& cast()
+    T cast()
     {
         if (policy->type() != typeid(T)) throw anyimpl::bad_any_cast();
         T* r = reinterpret_cast<T*>(policy->get_value(&object));
@@ -242,7 +242,7 @@ public:
 
     /// Cast operator. You can only cast to the original type.
     template<typename T>
-    const T& cast() const
+    const T cast() const
     {
         if (policy->type() != typeid(T)) throw anyimpl::bad_any_cast();
         const T* r = reinterpret_cast<const T*>(policy->get_value(&object));


### PR DESCRIPTION
When calling get_param in util.h this bug causes a reference to be returned to an address on the stack.