### PR TITLE
Clean: place arguments description in the correct order

### DIFF
--- a/src/cpp/flann/util/result_set.h
+++ b/src/cpp/flann/util/result_set.h
@@ -904,6 +904,7 @@ class KNNRadiusUniqueResultSet : public KNNUniqueResultSet<DistanceType>
 {
 public:
     /** Constructor
+     * @param radius the maximum distance of a neighbor
      * @param capacity the number of neighbors to store at max
      */
     KNNRadiusUniqueResultSet(DistanceType radius, size_t capacity) : KNNUniqueResultSet<DistanceType>(capacity)


### PR DESCRIPTION
Note that this order is reversed compared to the OpenCV's version.
We keep this discrepancy in both versions to avoid breaking interface for
applications using it.