### PR TITLE
Fixed bug in example where output of fscanf is unused

### DIFF
--- a/examples/flann_example.c
+++ b/examples/flann_example.c
@@ -28,7 +28,10 @@ float* read_points(const char* filename, int rows, int cols)
     
     for (i=0;i<rows;++i) {
         for (j=0;j<cols;++j) {
-            fscanf(fin,"%g ",p);
+            if(fscanf(fin,"%g ",p) != 1) {
+	    	printf("Input file is incorrectly formatted.\n");
+		exit(1);
+	    }
             p++;
         }
     }


### PR DESCRIPTION
Some combinations of C stdlib implementations and compilers will cause an error if the `fscanf()` return value is not used. This fix corrects that.