### PR TITLE
Optimize RadiusResultSet::copy

### DIFF
--- a/src/cpp/flann/util/result_set.h
+++ b/src/cpp/flann/util/result_set.h
@@ -492,7 +492,12 @@ public:
     	if (sorted) {
     		// std::sort_heap(dist_index_.begin(), dist_index_.end());
     		// sort seems faster here, even though dist_index_ is a heap
-    		std::sort(dist_index_.begin(), dist_index_.end());
+		std::partial_sort(
+			dist_index_.begin(),
+			num_elements<size()
+				? dist_index_.begin()+num_elements
+				: dist_index_.end(),
+			dist_index_.end());
     	}
     	else {
     		if (num_elements<size()) {


### PR DESCRIPTION
Perform std::partial_sort instead of full std::sort in RadiusResultSet if not all items need to be returned.