### PR TITLE
Set policy_max to 3.10 in cmake_minimum_required to support CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.12...3.10)
 
 if(COMMAND cmake_policy)
     cmake_policy(SET CMP0003 NEW)


### PR DESCRIPTION
Current flann fails configuration in CMake 4.0 with error:

~~~
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
~~~

Bumping just the [`policy_max`](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html) to 3.10 ensures that there are no errors or warnings when configuring with CMake 4.0, while keeping the existing compatibility with old CMake versions.
